### PR TITLE
Master

### DIFF
--- a/GoogleMapsComponents/Maps/Polygon.cs
+++ b/GoogleMapsComponents/Maps/Polygon.cs
@@ -18,7 +18,7 @@ namespace GoogleMapsComponents.Maps
         public Polygon(IJSRuntime jsRuntime, PolygonOptions opts = null)
             : base(jsRuntime)
         {
-            if(opts != null)
+            if (opts != null)
             {
                 _map = opts.Map;
 
@@ -149,7 +149,7 @@ namespace GoogleMapsComponents.Maps
             return _jsRuntime.InvokeWithDefinedGuidAsync<bool>(
                 "googleMapPolygonJsFunctions.setMap",
                 _guid.ToString(),
-                map.DivId);
+                map?.DivId);
         }
 
         /// <summary>

--- a/GoogleMapsComponents/Maps/Polyline.cs
+++ b/GoogleMapsComponents/Maps/Polyline.cs
@@ -142,7 +142,7 @@ namespace GoogleMapsComponents.Maps
             return _jsRuntime.InvokeWithDefinedGuidAndMethodAsync<bool>(
                 "googleMapPolylineJsFunctions.setMap",
                 _guid.ToString(),
-                map.DivId);
+                map?.DivId);
         }
 
         public Task SetOptions(PolylineOptions options)


### PR DESCRIPTION
BugFix. Fixed polygon and polyline method SetMap(map) when map is null. Passing null helps to clear polygons, polygones from GoogleMaps. Without fix it just crashed