### PR TITLE
Added support for LatLngBounds object

### DIFF
--- a/BlazorGoogleMaps.sln
+++ b/BlazorGoogleMaps.sln
@@ -11,6 +11,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServerSideDemo", "ServerSid
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClientSideDemo", "ClientSideDemo\ClientSideDemo.csproj", "{4391E333-F33D-4E18-8D45-1C6E73B77285}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8F72007D-A784-445E-907F-C68F6F9A72DA}"
+	ProjectSection(SolutionItems) = preProject
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/GoogleMapsComponents/MapComponent.cs
+++ b/GoogleMapsComponents/MapComponent.cs
@@ -1,12 +1,8 @@
 ﻿using Microsoft.JSInterop;
 using GoogleMapsComponents.Maps;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 
 namespace GoogleMapsComponents
 {

--- a/GoogleMapsComponents/Maps/LatLngBounds.cs
+++ b/GoogleMapsComponents/Maps/LatLngBounds.cs
@@ -13,10 +13,8 @@ namespace GoogleMapsComponents.Maps
         private readonly JsObjectRef _jsObjectRef;
 
         /// <summary>
-        /// Constructs a rectangle from the points at its south-west and north-east corners..
+        /// Constructs a new empty bounds
         /// </summary>
-        /// <param name="sw">South west corner</param>
-        /// <param name="ne">North east corner</param>
         public async static Task<LatLngBounds> CreateAsync(IJSRuntime jsRuntime)
         {
             var jsObjectRef = await JsObjectRef.CreateAsync(jsRuntime, "google.maps.LatLngBounds");
@@ -34,6 +32,24 @@ namespace GoogleMapsComponents.Maps
         public void Dispose()
         {
             _jsObjectRef.Dispose();
+        }
+
+        /// <summary>
+        /// Returns true if the given lat/lng is in this bounds.
+        /// </summary>
+        /// <returns></returns>
+        public Task<bool> Contains(LatLngLiteral other)
+        {
+            return _jsObjectRef.InvokeAsync<bool>("contains", other);
+        }
+
+        /// <summary>
+        /// Returns true if this bounds approximately equals the given bounds.
+        /// </summary>
+        /// <returns></returns>
+        public Task<bool> Equals(LatLngBoundsLiteral other)
+        {
+            return _jsObjectRef.InvokeAsync<bool>("equals", other);
         }
 
         /// <summary>
@@ -73,6 +89,24 @@ namespace GoogleMapsComponents.Maps
         }
         
         /// <summary>
+        /// Returns true if this bounds shares any points with the other bounds.
+        /// </summary>
+        /// <returns></returns>
+        public Task<bool> Intersects(LatLngBoundsLiteral other)
+        {
+            return _jsObjectRef.InvokeAsync<bool>("intersects", other);
+        }
+
+        /// <summary>
+        /// Returns true if the bounds are empty.
+        /// </summary>
+        /// <returns></returns>
+        public Task<bool> IsEmpty()
+        {
+            return _jsObjectRef.InvokeAsync<bool>("isEmpty");
+        }
+
+        /// <summary>
         /// Returns the literal representation of this bounds
         /// </summary>
         /// <returns></returns>
@@ -82,21 +116,31 @@ namespace GoogleMapsComponents.Maps
         }
 
         /// <summary>
-        /// Returns true if this bounds shares any points with the other bounds.
-        /// </summary>
-        /// <returns></returns>
-        public Task<bool> Intersects(LatLngBoundsLiteral other)
-        {
-            return _jsObjectRef.InvokeAsync<bool>("intersects", other);
-        }
-        
-        /// <summary>
         /// Returns true if the bounds are empty.
         /// </summary>
         /// <returns></returns>
-        public Task<bool> IsEmpty()
+        public Task<LatLngLiteral> ToSpan()
         {
-            return _jsObjectRef.InvokeAsync<bool>("isEmpty");
+            return _jsObjectRef.InvokeAsync<LatLngLiteral>("toSpan");
+        }
+
+        /// <summary>
+        /// Returns a string of the form "lat_lo,lng_lo,lat_hi,lng_hi" for this bounds,
+        /// where "lo" corresponds to the southwest corner of the bounding box, while "hi"
+        /// corresponds to the northeast corner of that box.
+        /// </summary>
+        /// <returns></returns>
+        public Task<string> ToUrlValue(double precision)
+        {
+            return _jsObjectRef.InvokeAsync<string>("toUrlValue", precision);
+        }
+
+        /// <summary>
+        /// Extends this bounds to contain the union of this and the given bounds.
+        /// </summary>
+        public Task Union(LatLngBoundsLiteral other)
+        {
+            return _jsObjectRef.InvokeAsync("union", other);
         }
     }
 }

--- a/GoogleMapsComponents/Maps/LatLngBounds.cs
+++ b/GoogleMapsComponents/Maps/LatLngBounds.cs
@@ -37,7 +37,6 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// Returns true if the given lat/lng is in this bounds.
         /// </summary>
-        /// <returns></returns>
         public Task<bool> Contains(LatLngLiteral other)
         {
             return _jsObjectRef.InvokeAsync<bool>("contains", other);
@@ -46,7 +45,6 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// Returns true if this bounds approximately equals the given bounds.
         /// </summary>
-        /// <returns></returns>
         public Task<bool> Equals(LatLngBoundsLiteral other)
         {
             return _jsObjectRef.InvokeAsync<bool>("equals", other);
@@ -55,7 +53,6 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// Extends this bounds to contain the given point.
         /// </summary>
-        /// <returns></returns>
         public Task Extend(LatLngLiteral point)
         {
             return _jsObjectRef.InvokeAsync("extend", point);
@@ -64,7 +61,6 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// Computes the center of this LatLngBounds
         /// </summary>
-        /// <returns></returns>
         public Task<LatLngLiteral> GetCenter()
         {
             return _jsObjectRef.InvokeAsync<LatLngLiteral>("getCenter");
@@ -73,7 +69,6 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// Returns the north-east corner of this bounds.
         /// </summary>
-        /// <returns></returns>
         public Task<LatLngLiteral> GetNorthEast()
         {
             return _jsObjectRef.InvokeAsync<LatLngLiteral>("getNorthEast");
@@ -82,7 +77,6 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// Returns the south-west corner of this bounds.
         /// </summary>
-        /// <returns></returns>
         public Task<LatLngLiteral> GetSouthWest()
         {
             return _jsObjectRef.InvokeAsync<LatLngLiteral>("getSouthWest");
@@ -91,7 +85,6 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// Returns true if this bounds shares any points with the other bounds.
         /// </summary>
-        /// <returns></returns>
         public Task<bool> Intersects(LatLngBoundsLiteral other)
         {
             return _jsObjectRef.InvokeAsync<bool>("intersects", other);
@@ -100,7 +93,6 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// Returns true if the bounds are empty.
         /// </summary>
-        /// <returns></returns>
         public Task<bool> IsEmpty()
         {
             return _jsObjectRef.InvokeAsync<bool>("isEmpty");
@@ -109,16 +101,14 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// Returns the literal representation of this bounds
         /// </summary>
-        /// <returns></returns>
         public Task<LatLngBoundsLiteral> ToJson()
         {
             return _jsObjectRef.InvokeAsync<LatLngBoundsLiteral>("toJSON");
         }
 
         /// <summary>
-        /// Returns true if the bounds are empty.
+        /// Converts the given map bounds to a lat/lng span.
         /// </summary>
-        /// <returns></returns>
         public Task<LatLngLiteral> ToSpan()
         {
             return _jsObjectRef.InvokeAsync<LatLngLiteral>("toSpan");
@@ -129,7 +119,6 @@ namespace GoogleMapsComponents.Maps
         /// where "lo" corresponds to the southwest corner of the bounding box, while "hi"
         /// corresponds to the northeast corner of that box.
         /// </summary>
-        /// <returns></returns>
         public Task<string> ToUrlValue(double precision)
         {
             return _jsObjectRef.InvokeAsync<string>("toUrlValue", precision);

--- a/GoogleMapsComponents/Maps/LatLngBounds.cs
+++ b/GoogleMapsComponents/Maps/LatLngBounds.cs
@@ -1,0 +1,102 @@
+﻿using Microsoft.JSInterop;
+using System;
+using System.Threading.Tasks;
+
+namespace GoogleMapsComponents.Maps
+{
+    /// <summary>
+    /// A LatLngBounds instance represents a rectangle in geographical coordinates,
+    /// including one that crosses the 180 degrees longitudinal meridian.
+    /// </summary>
+    public class LatLngBounds : IDisposable
+    {
+        private readonly JsObjectRef _jsObjectRef;
+
+        /// <summary>
+        /// Constructs a rectangle from the points at its south-west and north-east corners..
+        /// </summary>
+        /// <param name="sw">South west corner</param>
+        /// <param name="ne">North east corner</param>
+        public async static Task<LatLngBounds> CreateAsync(IJSRuntime jsRuntime)
+        {
+            var jsObjectRef = await JsObjectRef.CreateAsync(jsRuntime, "google.maps.LatLngBounds");
+
+            var obj = new LatLngBounds(jsObjectRef);
+
+            return obj;
+        }
+
+        private LatLngBounds(JsObjectRef jsObjectRef)
+        {
+            _jsObjectRef = jsObjectRef;
+        }
+
+        public void Dispose()
+        {
+            _jsObjectRef.Dispose();
+        }
+
+        /// <summary>
+        /// Extends this bounds to contain the given point.
+        /// </summary>
+        /// <returns></returns>
+        public Task Extend(LatLngLiteral point)
+        {
+            return _jsObjectRef.InvokeAsync("extend", point);
+        }
+        
+        /// <summary>
+        /// Computes the center of this LatLngBounds
+        /// </summary>
+        /// <returns></returns>
+        public Task<LatLngLiteral> GetCenter()
+        {
+            return _jsObjectRef.InvokeAsync<LatLngLiteral>("getCenter");
+        }
+
+        /// <summary>
+        /// Returns the north-east corner of this bounds.
+        /// </summary>
+        /// <returns></returns>
+        public Task<LatLngLiteral> GetNorthEast()
+        {
+            return _jsObjectRef.InvokeAsync<LatLngLiteral>("getNorthEast");
+        }
+
+        /// <summary>
+        /// Returns the south-west corner of this bounds.
+        /// </summary>
+        /// <returns></returns>
+        public Task<LatLngLiteral> GetSouthWest()
+        {
+            return _jsObjectRef.InvokeAsync<LatLngLiteral>("getSouthWest");
+        }
+        
+        /// <summary>
+        /// Returns the literal representation of this bounds
+        /// </summary>
+        /// <returns></returns>
+        public Task<LatLngBoundsLiteral> ToJson()
+        {
+            return _jsObjectRef.InvokeAsync<LatLngBoundsLiteral>("toJSON");
+        }
+
+        /// <summary>
+        /// Returns true if this bounds shares any points with the other bounds.
+        /// </summary>
+        /// <returns></returns>
+        public Task<bool> Intersects(LatLngBoundsLiteral other)
+        {
+            return _jsObjectRef.InvokeAsync<bool>("intersects", other);
+        }
+        
+        /// <summary>
+        /// Returns true if the bounds are empty.
+        /// </summary>
+        /// <returns></returns>
+        public Task<bool> IsEmpty()
+        {
+            return _jsObjectRef.InvokeAsync<bool>("isEmpty");
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Adding map in razor page without _Host.cshtml use  RenderComponentAsync<T> to re
 * InfoWindow
 * Polygon, LineString, Rectangle, Circle
 * Routes
+* Coordinates
+  * Bounds
 
 ## Work In Progress
 

--- a/ServerSideDemo/Pages/MapMarker.razor
+++ b/ServerSideDemo/Pages/MapMarker.razor
@@ -10,6 +10,8 @@
 <button @onclick="AddMarker">Add marker</button>
 <button @onclick="RemoveMarker">Remove marker</button>
 <button @onclick="Recenter">Re-center marker</button>
+<button @onclick="FitBounds">Fit to markers</button>
+
 
 <MapEventList @ref="@eventList" Events="@_events"></MapEventList>
 
@@ -26,7 +28,7 @@
 
     private LatLngBounds bounds;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
         mapOptions = new MapOptions()
         {
@@ -40,16 +42,21 @@
         };
     }
 
-    private async Task AddMarker()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (bounds == null)
+        if (firstRender)
         {
             bounds = await LatLngBounds.CreateAsync(map1.JsRuntime);
         }
+    }
+
+    private async Task AddMarker()
+    {
+        var mapCenter = await map1.InteropObject.GetCenter();
 
         var marker = await Marker.CreateAsync(map1.JsRuntime, new MarkerOptions()
         {
-            Position = await map1.InteropObject.GetCenter(),
+            Position = mapCenter,
             Map = map1.InteropObject,
             Label = $"Test {markers.Count}",
             Icon = new Icon()
@@ -59,17 +66,8 @@
             //Icon = "https://developers.google.com/maps/documentation/javascript/examples/full/images/beachflag.png"
         });
 
-        var pos = await marker.GetPosition();
-        await bounds.Extend(pos);
-
-        var boundsLiteral = await bounds.ToJson();
-
-        await map1.InteropObject.FitBounds(boundsLiteral, OneOf.OneOf<int, Padding>.FromT0(5));
-
-        //await marker.SetMap(map1);
-
-        //var map = await marker.GetMap();
-
+        await bounds.Extend(mapCenter);
+        
         var icon = await marker.GetIcon();
 
         Console.WriteLine($"Get icon result type is : {icon.Value.GetType()}");
@@ -78,15 +76,6 @@
             s => Console.WriteLine(s),
             i => Console.WriteLine(i.Url),
             _ => { });
-
-        //if (map == map1.InteropObject)
-        //{
-        //    Console.WriteLine("Yess");
-        //}
-        //else
-        //{
-        //    Console.WriteLine("Nooo");
-        //}
 
         markers.Push(marker);
 
@@ -123,4 +112,14 @@
         await lastMarker.SetPosition(center);
     }
 
+    private async Task FitBounds()
+    {
+        if (await this.bounds.IsEmpty())
+        {
+            return;
+        }
+
+        var boundsLiteral = await bounds.ToJson();
+        await map1.InteropObject.FitBounds(boundsLiteral, OneOf.OneOf<int, Padding>.FromT0(5));
+    }
 }

--- a/ServerSideDemo/Pages/MapMarker.razor
+++ b/ServerSideDemo/Pages/MapMarker.razor
@@ -2,6 +2,7 @@
 @using GoogleMapsComponents
 @using GoogleMapsComponents.Maps
 @using System.Diagnostics
+@using GoogleMapsComponents.Maps.Coordinates
 
 <h1>Google Map Markers</h1>
 
@@ -23,7 +24,9 @@
 
     private MapEventList eventList;
 
-    protected override void OnInitialized()
+    private LatLngBounds bounds;
+
+    protected override async Task OnInitializedAsync()
     {
         mapOptions = new MapOptions()
         {
@@ -39,17 +42,29 @@
 
     private async Task AddMarker()
     {
+        if (bounds == null)
+        {
+            bounds = await LatLngBounds.CreateAsync(map1.JsRuntime);
+        }
+
         var marker = await Marker.CreateAsync(map1.JsRuntime, new MarkerOptions()
         {
             Position = await map1.InteropObject.GetCenter(),
             Map = map1.InteropObject,
-            Label = $"Test {markers.Count()}",
+            Label = $"Test {markers.Count}",
             Icon = new Icon()
             {
                 Url = "https://developers.google.com/maps/documentation/javascript/examples/full/images/beachflag.png"
             }
             //Icon = "https://developers.google.com/maps/documentation/javascript/examples/full/images/beachflag.png"
         });
+
+        var pos = await marker.GetPosition();
+        await bounds.Extend(pos);
+
+        var boundsLiteral = await bounds.ToJson();
+
+        await map1.InteropObject.FitBounds(boundsLiteral, OneOf.OneOf<int, Padding>.FromT0(5));
 
         //await marker.SetMap(map1);
 
@@ -81,7 +96,7 @@
             _events.Add("click on " + markerLabel);
             StateHasChanged();
 
-            e.Stop();
+            await e.Stop();
         });
     }
 

--- a/ServerSideDemo/appsettings.Development.json
+++ b/ServerSideDemo/appsettings.Development.json
@@ -5,5 +5,6 @@
       "System": "Information",
       "Microsoft": "Information"
     }
-  }
+  },
+  "DetailedErrors": true 
 }


### PR DESCRIPTION
Based on the documented API surface that can be found [here](https://developers.google.com/maps/documentation/javascript/reference/coordinates#LatLngBounds)

Update the server-side demo app's MapMarker page so it now tracks markers to a bounds object and added a button that sets the map zoom/position to encompass the added markers.