### PR TITLE
Add AddListener() methods to Rectangle class.

### DIFF
--- a/GoogleMapsComponents/Maps/Rectangle.cs
+++ b/GoogleMapsComponents/Maps/Rectangle.cs
@@ -154,5 +154,21 @@ namespace GoogleMapsComponents.Maps
                 "setVisible",
                 visible);
         }
+        
+        public async Task<MapEventListener> AddListener(string eventName, Action handler)
+        {
+            var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
+                "addListener", eventName, handler);
+
+            return new MapEventListener(listenerRef);
+        }
+
+        public async Task<MapEventListener> AddListener<T>(string eventName, Action<T> handler)
+        {
+            var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
+                "addListener", eventName, handler);
+
+            return new MapEventListener(listenerRef);
+        }
     }
 }


### PR DESCRIPTION
Hi Rungwiroon!

To allow Rectangle to handle callbacks like Marker can, I copied the 2 AddListener() methods from Marker to Rectangle.  If this change is acceptable to you, and it's not too much trouble, can you also create a new nuget package including this change?

I am using GoogleMapsComponents in my project and it is working beautifully.
Thank you so much for making and maintaining this library!

Tzu-Han