### PR TITLE
Return DurationInTraffic when setting a DepartureTime in DrivingOptions by converting all ISO 8601 formatted strings into date objects

### DIFF
--- a/GoogleMapsComponents/Maps/DirectionsLeg.cs
+++ b/GoogleMapsComponents/Maps/DirectionsLeg.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 namespace GoogleMapsComponents.Maps
 {
     /// <summary>
@@ -10,6 +7,7 @@ namespace GoogleMapsComponents.Maps
     /// Some fields in the leg may not be returned for all requests. 
     /// Note that though this result is "JSON-like," it is not strictly JSON, as it directly and indirectly includes LatLng objects..
     /// </summary>
+
     public class DirectionsLeg
     {
         /// <summary>
@@ -37,28 +35,34 @@ namespace GoogleMapsComponents.Maps
         /// This property may be undefined as the duration may be unknown. 
         /// Only available to Premium Plan customers when drivingOptions is defined when making the request.
         /// </summary>
+
+        [JsonProperty("duration_in_traffic")]
         public Duration DurationInTraffic { get; set; }
 
         /// <summary>
         /// The address of the destination of this leg.
         /// </summary>
+        [JsonProperty("end_address")]
         public string EndAddress { get; set; }
 
         /// <summary>
         /// The DirectionsService calculates directions between locations by using the nearest transportation option (usually a road) at the start and end locations. 
         /// end_location indicates the actual geocoded destination, which may be different than the end_location of the last step if, for example, the road is not near the destination of this leg.
         /// </summary>
+        [JsonProperty("end_location")]
         public LatLngLiteral EndLocation { get; set; }
 
         /// <summary>
         /// The address of the origin of this leg.
         /// </summary>
+        [JsonProperty("start_address")]
         public string StartAddress { get; set; }
 
         /// <summary>
         /// The DirectionsService calculates directions between locations by using the nearest transportation option (usually a road) at the start and end locations. 
         /// start_location indicates the actual geocoded origin, which may be different than the start_location of the first step if, for example, the road is not near the origin of this leg.
         /// </summary>
+        [JsonProperty("start_location")]
         public LatLngLiteral StartLocation { get; set; }
 
         /// <summary>
@@ -72,6 +76,7 @@ namespace GoogleMapsComponents.Maps
         /// When using the Directions Service to implement draggable directions, it is recommended to disable dragging of alternative routes.
         /// Only the main route should be draggable.Users can drag the main route until it matches an alternative route.
         /// </summary>
+        [JsonProperty("via_waypoints")]
         public IEnumerable<LatLngLiteral> ViaWaypoints { get; set; }
     }
 }

--- a/GoogleMapsComponents/Maps/Places/PlacePlusCode.cs
+++ b/GoogleMapsComponents/Maps/Places/PlacePlusCode.cs
@@ -1,11 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
 namespace GoogleMapsComponents.Maps.Places
 {
     public class PlacePlusCode
     {
+        /// <summary>
+        /// It is  a 6 character or longer local code with an explicit location (CWC8+R9, Mountain View, CA, USA)
+        /// </summary>
+        [JsonPropertyName("compound_code")]
+        public string CompoundCode { get; set; }
+
+        /// <summary>
+        /// It is a 4 character area code and 6 character or longer local code (849VCWC8+R9)
+        /// </summary>
+        [JsonPropertyName("global_code")]
+        public string GlobalCode { get; set; }
     }
 }

--- a/GoogleMapsComponents/Maps/Places/PlaceResult.cs
+++ b/GoogleMapsComponents/Maps/Places/PlaceResult.cs
@@ -56,6 +56,14 @@ namespace GoogleMapsComponents.Maps.Places
         public string PlaceId { get; set; }
 
         /// <summary>
+        /// Plus codes can be used as a replacement for street addresses in places where they do not exist (where buildings are not numbered or streets are not named).
+        /// The plus code is formatted as a global code and a compound code
+        /// Typically, both the global code and compound code are returned. However, if the result is in a remote location (for example, an ocean or desert) only the global code may be returned.
+        /// </summary>
+        [JsonPropertyName("plus_code")]
+        public PlacePlusCode PlusCode { get; set; }
+
+        /// <summary>
         /// URL of the official Google page for this place. This is the Google-owned page that contains
         /// the best available information about the Place. Only available with PlacesService.getDetails.
         /// </summary>

--- a/GoogleMapsComponents/Maps/TrafficModel.cs
+++ b/GoogleMapsComponents/Maps/TrafficModel.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,21 +11,23 @@ namespace GoogleMapsComponents.Maps
     /// The assumptions to use when predicting duration in traffic. 
     /// Specified as part of a DirectionsRequest or DistanceMatrixRequest. 
     /// </summary>
+
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum TrafficModel
     {
         /// <summary>
         /// Use historical traffic data to best estimate the time spent in traffic.
         /// </summary>
-        BestGuess,
+        bestguess,
 
         /// <summary>
         /// Use historical traffic data to make an optimistic estimate of what the duration in traffic will be.
         /// </summary>
-        Optimistic,
+        optimistic,
 
         /// <summary>
         /// Use historical traffic data to make a pessimistic estimate of what the duration in traffic will be.
         /// </summary>
-        Pessimistic
+        pessimistic
     }
 }

--- a/GoogleMapsComponents/wwwroot/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/objectManager.js
@@ -13,6 +13,15 @@
     return fn;
 }
 
+const dateFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+
+function dateObjectReviver(key, value) {
+    if (typeof value === "string" && dateFormat.test(value)) {
+        return new Date(value);
+    }
+    return value;
+}
+
 function tryParseJson(item) {
     //console.log(item);
 
@@ -52,7 +61,7 @@ function tryParseJson(item) {
     let item2 = null;
 
     try {
-        item2 = JSON.parse(item);
+        item2 = JSON.parse(item, dateObjectReviver);
     } catch (e) {
         return item.replace(/['"]+/g, '');
     }


### PR DESCRIPTION
We were having trouble requesting direction requests with a departure time set in the driving options (in order to get back a duration in traffic rather than just duration).

This code converts all ISO 8601 formatted strings into date objects which fixed the problem. It should also work with the transit options as well but we haven't tested it.