### PR TITLE
Return OverviewPolyline in DirectionsRoute object

### DIFF
--- a/GoogleMapsComponents/Maps/DirectionsRoute.cs
+++ b/GoogleMapsComponents/Maps/DirectionsRoute.cs
@@ -45,6 +45,7 @@ namespace GoogleMapsComponents.Maps
         /// An encoded polyline representation of the route in overview_path. 
         /// This polyline is an approximate (smoothed) path of the resulting directions.
         /// </summary>
+        [JsonProperty("overview_polyline")]
         public string OverviewPolyline { get; set; }
 
         /// <summary>

--- a/GoogleMapsComponents/wwwroot/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/objectManager.js
@@ -100,7 +100,6 @@ function cleanDirectionResult(dirResponse) {
 
     tmpdirobj.routes.forEach((r) => {
       //  r.overview_path = [];
-        r.overview_polyline = [];
 
         r.legs.forEach((l) => {
             l.lat_lngs = [];


### PR DESCRIPTION
Hi there,

This code enables the return of the OverviewPolyline property in a DirectionsRoute of a DirectionsResult.

Not sure why it was purposefully being removed from the object returned from js.

Without this modification, the AddDirections method in MapRoutes demo page would not return any value to the OverviewPolyline property of the routes in the _directionsResult.