### PR TITLE
Add optional DirectionsRequestOptions to DirectionsRenderer.GetDirections

### DIFF
--- a/GoogleMapsComponents/Maps/DirectionsRenderer.cs
+++ b/GoogleMapsComponents/Maps/DirectionsRenderer.cs
@@ -43,8 +43,8 @@ namespace GoogleMapsComponents.Maps
             }
 
             var response = await _jsObjectRef.InvokeAsync<string>(
-                    "googleMapDirectionServiceFunctions.route",
-                    request, directionsRequestOptions);
+                "googleMapDirectionServiceFunctions.route",
+                request, directionsRequestOptions);
             try
             {
                 var dirResult = JsonConvert.DeserializeObject<DirectionsResult>(response);
@@ -77,15 +77,25 @@ namespace GoogleMapsComponents.Maps
                 directions);
         }
 
-        public async Task<DirectionsResult> GetDirections()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="directionsRequestOptions">Lets you specify which route response paths to opt out from clearing.</param>
+        /// <returns></returns>
+        public async Task<DirectionsResult> GetDirections(DirectionsRequestOptions directionsRequestOptions = null)
         {
+            if (directionsRequestOptions == null)
+            {
+                directionsRequestOptions = new DirectionsRequestOptions();
+            }
+
             var response = await _jsObjectRef.InvokeAsync<string>(
-                "getDirections");
+                "getDirections",
+                directionsRequestOptions);
             try
             {
-                var DirResult = JsonConvert.DeserializeObject<DirectionsResult>(response);
-
-                return DirResult;
+                var dirResult = JsonConvert.DeserializeObject<DirectionsResult>(response);
+                return dirResult;
             }
             catch (Exception e)
             {

--- a/GoogleMapsComponents/wwwroot/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/objectManager.js
@@ -160,7 +160,7 @@ window.googleMapsObjectManager = {
 
     disposeMapElements(mapGuid) {
         var keysToRemove = [];
-       
+
         for (var key in _blazorGoogleMapsObjects) {
             if (_blazorGoogleMapsObjects.hasOwnProperty(key)) {
                 var element = _blazorGoogleMapsObjects[key];
@@ -211,7 +211,7 @@ window.googleMapsObjectManager = {
             try {
                 let result = await promise;
                 obj.setDirections(result);
-                
+
                 let jsonRest = JSON.stringify(cleanDirectionResult(result, dirRequestOptions));
                 //console.log(JSON.stringify(jsonRest));
                 return jsonRest;
@@ -221,42 +221,55 @@ window.googleMapsObjectManager = {
             }
 
         }
-        else {
-            var result = null;
-            try {
-                result = obj[args[1]](...args2);
-            } catch (e) {
-                console.log(e);
-            }
+        else
+            if (args[1] == "getDirections") {
+                let dirRequestOptions = args2[0];
 
-            if (result !== null
-                && typeof result === "object") {
-                if (result.hasOwnProperty("geocoded_waypoints") && result.hasOwnProperty("routes")) {
-                    
-                    let jsonRest = JSON.stringify(cleanDirectionResult(result));
-                    return jsonRest;
+                try {
+                    var result = obj[args[1]]();
+                } catch (e) {
+                    console.log(e);
                 }
-                if ("getArray" in result) {
-                    return result.getArray();
+
+                let jsonRest = JSON.stringify(cleanDirectionResult(result, dirRequestOptions));
+                return jsonRest;
+            }
+            else {
+                var result = null;
+                try {
+                    result = obj[args[1]](...args2);
+                } catch (e) {
+                    console.log(e);
                 }
-                if ("get" in result) {
-                    return result.get("guidString");
-                } else if ("dotnetTypeName" in result) {
-                    return JSON.stringify(result);
+
+                if (result !== null
+                    && typeof result === "object") {
+                    if (result.hasOwnProperty("geocoded_waypoints") && result.hasOwnProperty("routes")) {
+
+                        let jsonRest = JSON.stringify(cleanDirectionResult(result));
+                        return jsonRest;
+                    }
+                    if ("getArray" in result) {
+                        return result.getArray();
+                    }
+                    if ("get" in result) {
+                        return result.get("guidString");
+                    } else if ("dotnetTypeName" in result) {
+                        return JSON.stringify(result);
+                    } else {
+                        return result;
+                    }
                 } else {
                     return result;
                 }
-            } else {
-                return result;
             }
-        }
     },
 
     invokeWithReturnedObjectRef: function (args) {
         let result = googleMapsObjectManager.invoke(args);
         let uuid = uuidv4();
 
-        
+
         //console.log("invokeWithReturnedObjectRef " + uuid);
 
         //Removed since here exists only events and whats point of having event in this array????


### PR DESCRIPTION
Thanks @valentasm1 for the changes made in pull request #48.

Further to that, here I have added an optional `DirectionsRequestOptions` to `DirectionsRenderer.GetDirections`.
This is useful if you want to add a listener for `directions_changed` to your `DirectionsRenderer` to get the latest `DirectionsResult` after user interaction with the map.

I'm really not sure about the javascript changes I made so please take a close look at that. I'm not very familiar with js.

The following code changes for MapRoutes.razor.cs allow a user to alter the displayed route on the map and still generate distance and duration totals.

```
        private async Task OnAfterInitAsync()
        {
            //Create instance of DirectionRenderer
            dirRend = await DirectionsRenderer.CreateAsync(map1.JsRuntime, new DirectionsRendererOptions()
            {
                Draggable = true,
                Map = map1.InteropObject
            });

            await dirRend.AddListener("directions_changed", async () =>
            {
                _directionsResult = await dirRend.GetDirections(new DirectionsRequestOptions()
                {
                    StripLegsStepsLatLngs = false,
                    StripOverviewPath = false,
                    StripOverviewPolyline = false,
                    StripLegsStepsPath = false,
                    StripLegsSteps = false
                });

                var routes = _directionsResult.Routes.SelectMany(x => x.Legs).ToList();

                _durationTotalString = null;
                _distanceTotalString = null;

                foreach (var route in routes)
                {
                    _durationTotalString += route.DurationInTraffic?.Text ?? route.Duration.Text;
                    _distanceTotalString += route.Distance.Text;
                }

                StateHasChanged();
            });
        }

        private async Task AddDirections()
        {
            //Adding a waypoint
            var waypoints = new List<DirectionsWaypoint>();
            waypoints.Add(new DirectionsWaypoint() { Location = "Bethlehem, PA", Stopover = true });

            //Direction Request
            DirectionsRequest dr = new DirectionsRequest();
            dr.Origin = "Allentown, PA";
            dr.Destination = "Bronx, NY";
            dr.Waypoints = waypoints;
            dr.TravelMode = TravelMode.Driving;
            dr.DrivingOptions = new DrivingOptions()
            {
                DepartureTime = DateTime.Now.AddHours(1)
            };

            //Calculate Route
            await dirRend.Route(dr);
        }
    }
```

I didn't make this part of the pull request as I thought it might be confusing to new comers, as to why we don't just use the `DirectionsResult` returned from calling `await dirRend.Route(dr);`.