### PR TITLE
Updated marker clusterer reference in demo app.

### DIFF
--- a/ServerSideDemo/Pages/_Host.cshtml
+++ b/ServerSideDemo/Pages/_Host.cshtml
@@ -21,6 +21,6 @@
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/BlazorGoogleMaps/objectManager.js"></script>
 <script src="js/serverSideScripts.js"></script>
-<script src="https://unpkg.com/@@google/markerclustererplus@4.0.1/dist/markerclustererplus.min.js"></script>
+<script src="https://unpkg.com/@@googlemaps/markerclustererplus/dist/index.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
According to https://github.com/googlemaps/js-markerclustererplus, this is the new reference to use.