### PR TITLE
Make DirectionsService.Route method return a DirectionsResult

### DIFF
--- a/GoogleMapsComponents/Maps/DirectionsService.cs
+++ b/GoogleMapsComponents/Maps/DirectionsService.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.JSInterop;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace GoogleMapsComponents.Maps
@@ -14,7 +10,6 @@ namespace GoogleMapsComponents.Maps
     /// </summary>
     public class DirectionsService : IDisposable
     {
-        private readonly string jsObjectName = "googleMapDirectionServiceFunctions";
         private readonly JsObjectRef _jsObjectRef;
 
         /// <summary>
@@ -46,14 +41,29 @@ namespace GoogleMapsComponents.Maps
         /// Issue a directions search request.
         /// </summary>
         /// <param name="request"></param>
-        /// <param name="callback"></param>
-        public async Task<DirectionResponse> Route(DirectionsRequest request)
+        /// <param name="directionsRequestOptions">Lets you specify which route response paths to opt out from clearing.</param>
+        /// <returns></returns>
+        public async Task<DirectionsResult> Route(DirectionsRequest request, DirectionsRequestOptions directionsRequestOptions = null)
         {
-            await _jsObjectRef.InvokeAsync(
-                    $"{jsObjectName}.route",
-                    request);
+            if (directionsRequestOptions == null)
+            {
+                directionsRequestOptions = new DirectionsRequestOptions();
+            }
 
-            return null;
+            var response = await _jsObjectRef.InvokeAsync<string>(
+                "googleMapDirectionServiceFunctions.route",
+                request, directionsRequestOptions);
+            try
+            {
+                var dirResult = JsonConvert.DeserializeObject<DirectionsResult>(response);
+                return dirResult;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Error parsing DirectionsResult Object. Message: " + e.Message);
+                return null;
+            }
+
         }
     }
 }

--- a/GoogleMapsComponents/wwwroot/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/objectManager.js
@@ -298,7 +298,9 @@ window.googleMapsObjectManager = {
             //Wait for promise
             try {
                 let result = await promise;
-                obj.setDirections(result);
+                if (typeof obj.setDirections === "function") {
+                    obj.setDirections(result);
+                }
 
                 let jsonRest = JSON.stringify(cleanDirectionResult(result, dirRequestOptions));
                 //console.log(JSON.stringify(jsonRest));


### PR DESCRIPTION
Hi there,

We are wanting to have `DirectionsService.Route` return a `DirectionsResult`. We have been (and still do) use `DirectionsRenderer.Route` to do this, but we wanted to be able to query the Api without displaying the results on the map.

We investigated making HTTP calls directly to the Directions Api but Google blocks this (through CORS) when you are calling from a browser (as in Blazor WebAssembly) so the only option is the use the Javascript Api.

The original `DirectionsService.Route` returned a `DirectionResponse` but on inspecting the code it was always null.

To solve the issue we copied the code from the `DirectionsRenderer.Route` method. We also had to change `objectManager.js` to ensure that the `setDirections` method was only called if it existed. `setDirections` does exist in `DirectionsRenderer` but not in `DirectionsService`.

We realise changing the return type of `DirectionsService.Route` to a `DirectionResponse` is a breaking change but, without wanting to offend, the original code would always return `null` anyway, so we don't believe this would be an issue for anyone using the library already.

To test the result of this PR, replacing the code in `MapRoutes.razor.cs` in the demo with the following code will get the route result and update the duration and distance but not draw the route on the map.
```
        private DirectionsService dirService;

        private async Task OnAfterInitAsync()
        {
            //Create instance of DirectionRenderer
            dirRend = await DirectionsRenderer.CreateAsync(map1.JsRuntime, new DirectionsRendererOptions()
            {
                Map = map1.InteropObject
            });

            dirService = await DirectionsService.CreateAsync(map1.JsRuntime);
        }

        private async Task AddDirections()
        {
            //Adding a waypoint
            var waypoints = new List<DirectionsWaypoint>();
            waypoints.Add(new DirectionsWaypoint() { Location = "Bethlehem, PA", Stopover = true });

            //Direction Request
            DirectionsRequest dr = new DirectionsRequest();
            dr.Origin = "Allentown, PA";
            dr.Destination = "Bronx, NY";
            dr.Waypoints = waypoints;
            dr.TravelMode = TravelMode.Driving;
            dr.DrivingOptions = new DrivingOptions()
            {
                DepartureTime = DateTime.Now.AddHours(1)
            };

            //Calculate Route
            _directionsResult = await dirService.Route(dr, new DirectionsRequestOptions()
            {
                StripLegsStepsLatLngs = false,
                StripOverviewPath = false,
                StripOverviewPolyline = false,
                StripLegsStepsPath = false,
                StripLegsSteps = false
            });


            var routes = _directionsResult.Routes.SelectMany(x => x.Legs).ToList();

            foreach (var route in routes)
            {
                _durationTotalString += route.DurationInTraffic?.Text;
                _distanceTotalString += route.Distance.Text;
            }
        }
```