### PR TITLE
Added Repaint method to MarkerClustering.  Updated some xml comments.

### DIFF
--- a/GoogleMapsComponents/Maps/MarkerClustererOptions.cs
+++ b/GoogleMapsComponents/Maps/MarkerClustererOptions.cs
@@ -31,7 +31,7 @@ namespace GoogleMapsComponents.Maps
         public int? BatchSize { get; set; }
 
         /// <summary>
-        /// The name of the CSS class defining general styles
+        /// The name of the CSS class defining general styles for the cluster markers.
         /// </summary>
         public string? ClusterClass { get; set; }
 
@@ -49,9 +49,9 @@ namespace GoogleMapsComponents.Maps
         public int? GridSize { get; set; }
 
         /// <summary>
-        /// Whether to ignore hidden markers in clusters.You
+        /// Whether to ignore hidden markers in clusters. You
         /// may want to set this to `true` to ensure that hidden markers are not included
-        /// in the marker count that appears on a cluster marker
+        /// in the marker count that appears on a cluster marker.
         /// </summary>
         public bool? IgnoreHidden { get; set; }
 
@@ -82,9 +82,9 @@ namespace GoogleMapsComponents.Maps
         public int? ZIndex { get; set; }
 
         /// <summary>
-        /// Whether the position of a cluster marker should be
-        /// the average position of all markers in the cluster.If set to `false`, the
-        /// cluster marker is positioned at the location of the first marker added to the cluster.
+        /// Whether to zoom the map when a cluster marker is clicked. You may want to
+        /// set this to `false` if you have installed a handler for the `click` event
+        /// and it deals with zooming on its own.
         /// </summary>
         public bool? ZoomOnClick { get; set; }
     }

--- a/GoogleMapsComponents/Maps/MarkerClustering.cs
+++ b/GoogleMapsComponents/Maps/MarkerClustering.cs
@@ -76,14 +76,29 @@ namespace GoogleMapsComponents.Maps
             await _jsObjectRef.InvokeAsync("setMap", map);
         }
 
+        /// <summary>
+        /// Removes all clusters and markers from the map and also removes all markers managed by the clusterer.
+        /// </summary>
         public virtual async Task ClearMarkers()
         {
             await _jsObjectRef.InvokeAsync("clearMarkers");
         }
 
+        /// <summary>
+        /// Fits the map to the bounds of the markers managed by the clusterer.
+        /// </summary>
+        /// <param name="padding"></param>
         public virtual async Task FitMapToMarkers(int padding)
         {
             await _jsObjectRef.InvokeAsync("fitMapToMarkers", padding);
+        }
+
+        /// <summary>
+        /// Recalculates and redraws all the marker clusters from scratch. Call this after changing any properties.
+        /// </summary>
+        public virtual async Task Repaint()
+        {
+            await _jsObjectRef.InvokeAsync("repaint");
         }
 
         public virtual async Task ClearListeners(string eventName)


### PR DESCRIPTION
This PR is just to expose the `Repaint` method for the marker clusterer.  The use case is for where map markers are added, removed, changed visibility, or changed position - calling `Repaint()` after any such changes ensures that the clustered markers reflect the updated situation.