### PR TITLE
Add PolygonListener Support

### DIFF
--- a/GoogleMapsComponents/wwwroot/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/objectManager.js
@@ -427,7 +427,11 @@ window.googleMapsObjectManager = {
 
             let jsonRest = JSON.stringify(cleanDirectionResult(result, dirRequestOptions));
             return jsonRest;
-        } else {
+        }
+        else if (args2[0] == "polygoncomplete") { //if the event is polygoncomplete, add the event to remove polygons from the map
+            this.addDrawingCompleteListener(obj, "polygon");
+        }
+        else {
             var result = null;
             try {
                 result = obj[functionToInvoke](...args2);
@@ -571,5 +575,11 @@ window.googleMapsObjectManager = {
         }
 
         window._blazorGoogleMapsObjects[guid] = markerCluster;
+    },
+
+    addDrawingCompleteListener(drawingManager, drawingType) {
+        google.maps.event.addListener(drawingManager, drawingType + 'complete', function (drawing) {
+            drawing.setMap(null); //remove the item from the map so we can manually add it again later
+        });
     }
 };

--- a/ServerSideDemo/Pages/DrawingManagerPage.razor
+++ b/ServerSideDemo/Pages/DrawingManagerPage.razor
@@ -9,4 +9,5 @@
 <GoogleMap @ref="@map1" Id="map1" Options="@mapOptions" OnAfterInit="@(async () => await OnAfterInitAsync())"></GoogleMap>
 <button @onclick="ChangeDrawingModeToLine">Change mode to line</button>
 <button @onclick="StopDrawingMode">Stop drawing mode</button>
+<button @onclick="AddPolygonListener">Add Polygon Listener</button>
 @*<div id="map" @ref="@map1ElementRef" style="height: 450px"></div>*@

--- a/ServerSideDemo/Pages/DrawingManagerPage.razor.cs
+++ b/ServerSideDemo/Pages/DrawingManagerPage.razor.cs
@@ -95,5 +95,13 @@ namespace ServerSideDemo.Pages
             await drawingManager.SetDrawingMode(null);
 
         }
+
+        private async Task AddPolygonListener()
+        {
+            await drawingManager.AddPolygonCompleteListener(map1.JsRuntime, (polygon) =>
+            {
+                Console.WriteLine(polygon.GetPath());
+            });
+        }
     }
 }


### PR DESCRIPTION
This addresses the lack of polygoncomplete support identified here: https://github.com/rungwiroon/BlazorGoogleMaps/issues/148

It is essentially a workaround to get this to work.

In short, this PR:

- Adds a JS function that removes polygons as soon as they are added by the drawing manager by setting their map to null
- Adds an event in drawing manager that parses the results of an overlaycomplete event and creates a new polygon that can be returned to the user.
- What I have done, in short, is wrapped the overlaycomplete event in a polygoncomplete event.

Please let me know what you think of this. Right now it only supports Polygons but could be expanded to include Polylines, circles, etc. I will leave this is a draft PR for now.