### PR TITLE
moved objectManager to /js folder; implemented ImageMapType

### DIFF
--- a/ClientSideDemo/wwwroot/index.html
+++ b/ClientSideDemo/wwwroot/index.html
@@ -13,6 +13,6 @@
     <app>Loading...</app>
 
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/BlazorGoogleMaps/objectManager.js"></script>
+    <script src="_content/BlazorGoogleMaps/js/objectManager.js"></script>
 </body>
 </html>

--- a/ClientSideDemoNet5/wwwroot/index.html
+++ b/ClientSideDemoNet5/wwwroot/index.html
@@ -13,7 +13,7 @@
     <app>Loading...</app>
 
     <script src="_framework/blazor.webassembly.js"></script>
-    <!--<script src="_content/BlazorGoogleMaps/objectManager.js"></script>-->
+    <script src="_content/BlazorGoogleMaps/js/objectManager.js"></script>
     <script src="https://unpkg.com/@googlemaps/markerclustererplus/dist/index.min.js"></script>
 </body>
 </html>

--- a/ClientSideDemoNet5/wwwroot/index.html
+++ b/ClientSideDemoNet5/wwwroot/index.html
@@ -13,7 +13,7 @@
     <app>Loading...</app>
 
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="_content/BlazorGoogleMaps/objectManager.js"></script>
+    <!--<script src="_content/BlazorGoogleMaps/objectManager.js"></script>-->
     <script src="https://unpkg.com/@googlemaps/markerclustererplus/dist/index.min.js"></script>
 </body>
 </html>

--- a/GoogleMapsComponents/GoogleMap.razor
+++ b/GoogleMapsComponents/GoogleMap.razor
@@ -5,7 +5,7 @@
 @using Microsoft.JSInterop
 
 @inherits MapComponent
-@implements IAsyncDisposable
+@implements IDisposable
 @inject IJSRuntime JSRuntime
 
 <div @ref="@Element" id="@Id" class="@CssClass" style="@StyleStr"></div>
@@ -14,7 +14,7 @@
     #nullable enable
     // Load the module and keep a reference to it
     // You need to use .AsTask() to convert the ValueTask to Task as it may be awaited multiple times
-    private List<IJSObjectReference> moduleImports = new List<IJSObjectReference>();
+    //private List<IJSObjectReference> moduleImports = new List<IJSObjectReference>();
 
     [Parameter]
     public string? Id { get; set; }
@@ -52,12 +52,12 @@
     {
         if (firstRender)
         {
-            var tasks = new List<Task<IJSObjectReference>>();
-            tasks.Add(JSRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/BlazorGoogleMaps/js/objectManager.js").AsTask());
-            if(!string.IsNullOrWhiteSpace(ApiKey))
-                tasks.Add(JSRuntime.InvokeAsync<IJSObjectReference>("import", $"https://maps.googleapis.com/maps/api/js?key={ApiKey}&v=3").AsTask());
+            //var tasks = new List<Task<IJSObjectReference>>();
+            //tasks.Add(JSRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/BlazorGoogleMaps/js/objectManager.js").AsTask());
+            //if(!string.IsNullOrWhiteSpace(ApiKey))
+            //    tasks.Add(JSRuntime.InvokeAsync<IJSObjectReference>("import", $"https://maps.googleapis.com/maps/api/js?key={ApiKey}&v=3").AsTask());
 
-            moduleImports.AddRange(await Task.WhenAll(tasks.ToArray()));
+            //moduleImports.AddRange(await Task.WhenAll(tasks.ToArray()));
         }
 
         await InitAsync(Element, Options);
@@ -72,12 +72,12 @@
         return false;
     }
 
-    async ValueTask IAsyncDisposable.DisposeAsync()
+    void IDisposable.Dispose()
     {
-        if(moduleImports != null && moduleImports.Count > 0)
-        {
-            foreach (var mi in moduleImports)
-                await mi.DisposeAsync();
-        }
+        //if(moduleImports != null && moduleImports.Count > 0)
+        //{
+        //    foreach (var mi in moduleImports)
+        //        await mi.DisposeAsync();
+        //}
     }
 }

--- a/GoogleMapsComponents/GoogleMap.razor
+++ b/GoogleMapsComponents/GoogleMap.razor
@@ -2,17 +2,25 @@
 @using Maps
 @using System.Threading.Tasks
 @using Microsoft.AspNetCore.Components
+@using Microsoft.JSInterop
 
 @inherits MapComponent
-@implements System.IDisposable
+@implements IAsyncDisposable
+@inject IJSRuntime JSRuntime
 
 <div @ref="@Element" id="@Id" class="@CssClass" style="@StyleStr"></div>
 
 @code {
     #nullable enable
+    // Load the module and keep a reference to it
+    // You need to use .AsTask() to convert the ValueTask to Task as it may be awaited multiple times
+    private List<IJSObjectReference> moduleImports = new List<IJSObjectReference>();
 
     [Parameter]
     public string? Id { get; set; }
+
+    [Parameter]
+    public string ApiKey { get; set; } = string.Empty;
 
     [Parameter]
     public MapOptions? Options { get; set; }
@@ -42,6 +50,15 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            var tasks = new List<Task<IJSObjectReference>>();
+            tasks.Add(JSRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/BlazorGoogleMaps/js/objectManager.js").AsTask());
+            if(!string.IsNullOrWhiteSpace(ApiKey))
+                tasks.Add(JSRuntime.InvokeAsync<IJSObjectReference>("import", $"https://maps.googleapis.com/maps/api/js?key={ApiKey}&v=3").AsTask());
+
+            moduleImports.AddRange(await Task.WhenAll(tasks.ToArray()));
+        }
 
         await InitAsync(Element, Options);
 
@@ -55,5 +72,12 @@
         return false;
     }
 
-
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if(moduleImports != null && moduleImports.Count > 0)
+        {
+            foreach (var mi in moduleImports)
+                await mi.DisposeAsync();
+        }
+    }
 }

--- a/GoogleMapsComponents/GoogleMapsComponents.csproj
+++ b/GoogleMapsComponents/GoogleMapsComponents.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <RestoreAdditionalProjectSources>
       https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
@@ -52,8 +52,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.21" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.21" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OneOf" Version="2.1.151" />

--- a/GoogleMapsComponents/GoogleMapsComponents.csproj
+++ b/GoogleMapsComponents/GoogleMapsComponents.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <RestoreAdditionalProjectSources>
       https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
@@ -52,8 +52,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.12" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OneOf" Version="2.1.151" />

--- a/GoogleMapsComponents/Maps/ImageMapType.cs
+++ b/GoogleMapsComponents/Maps/ImageMapType.cs
@@ -15,11 +15,12 @@ namespace GoogleMapsComponents.Maps
         public Guid Guid => _jsObjectRef.Guid;
         public string Name { get; private set; }
         GoogleMap map = null;
-        public async static Task<ImageMapType> CreateAsync(IJSRuntime jsRuntime, string baseUrl, int minZoom, int maxZoom, string name, float opacity)
+        public async static Task<ImageMapType> CreateAsync(IJSRuntime jsRuntime, string baseUrlFormat, int minZoom, int maxZoom, string name, float opacity)
         {
+            var realUrl = baseUrlFormat.Replace("{z}", "' + zoom + '").Replace("{x}", "' + coord.x + '").Replace("{y}", "' + coord.y + '");
             string initOpts = @"{
                 'getTileUrl': (coord, zoom) => {
-                            return '" + baseUrl + @"' + zoom + '/' + coord.x + '/' + coord.y;
+                            return '" + realUrl + @"'
                         },
                 'tileSize': new google.maps.Size(256, 256),
                 'maxZoom': " + maxZoom.ToString() + @",
@@ -27,6 +28,17 @@ namespace GoogleMapsComponents.Maps
                 'opacity': " + opacity.ToString() + @",
                 'name': '" + name + @"'
             }";
+
+            //string initOpts = @"{
+            //    'getTileUrl': (coord, zoom) => {
+            //                return '" + baseUrl + @"' + zoom + '/' + coord.x + '/' + coord.y;
+            //            },
+            //    'tileSize': new google.maps.Size(256, 256),
+            //    'maxZoom': " + maxZoom.ToString() + @",
+            //    'minZoom': " + minZoom.ToString() + @",
+            //    'opacity': " + opacity.ToString() + @",
+            //    'name': '" + name + @"'
+            //}";
 
             var jsObjectRef = await JsObjectRef.CreateAsync(jsRuntime, "google.maps.ImageMapType", initOpts);
             var to = new ImageMapType(jsObjectRef) {

--- a/GoogleMapsComponents/Maps/ImageMapType.cs
+++ b/GoogleMapsComponents/Maps/ImageMapType.cs
@@ -1,11 +1,87 @@
-﻿using System;
+﻿using Microsoft.JSInterop;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace GoogleMapsComponents.Maps
 {
-    public class ImageMapType
+    public class ImageMapType : IDisposable
     {
+        private readonly JsObjectRef _jsObjectRef;
+
+        public readonly Dictionary<string, List<MapEventListener>> EventListeners;
+
+        public Guid Guid => _jsObjectRef.Guid;
+        public string Name { get; private set; }
+        GoogleMap map = null;
+        public async static Task<ImageMapType> CreateAsync(IJSRuntime jsRuntime, string baseUrl, int minZoom, int maxZoom, string name, float opacity)
+        {
+            string initOpts = @"{
+                'getTileUrl': (coord, zoom) => {
+                            return '" + baseUrl + @"' + zoom + '/' + coord.x + '/' + coord.y;
+                        },
+                'tileSize': new google.maps.Size(256, 256),
+                'maxZoom': " + maxZoom.ToString() + @",
+                'minZoom': " + minZoom.ToString() + @",
+                'opacity': " + opacity.ToString() + @",
+                'name': '" + name + @"'
+            }";
+
+            var jsObjectRef = await JsObjectRef.CreateAsync(jsRuntime, "google.maps.ImageMapType", initOpts);
+            var to = new ImageMapType(jsObjectRef) {
+                Name = name
+            };
+            return to;
+        }
+
+        internal ImageMapType(JsObjectRef jsObjectRef)
+        {
+            _jsObjectRef = jsObjectRef;
+            EventListeners = new Dictionary<string, List<MapEventListener>>();
+        }
+
+        public async Task<MapEventListener> AddListener(string eventName, Action handler)
+        {
+            JsObjectRef listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync("addListener", eventName, handler);
+            MapEventListener eventListener = new MapEventListener(listenerRef);
+
+            if (!EventListeners.ContainsKey(eventName))
+            {
+                EventListeners.Add(eventName, new List<MapEventListener>());
+            }
+            EventListeners[eventName].Add(eventListener);
+
+            return eventListener;
+        }
+
+        /// <summary>
+        /// The opacity of the overlay, expressed as a number between 0 and 1. Optional. Defaults to 1.
+        /// </summary>
+        /// <param name="opacity"></param>
+        /// <returns></returns>
+        public async Task SetOpacity(double opacity)
+        {
+            if (opacity > 1) return;
+            if (opacity < 0) return;
+
+            await _jsObjectRef.InvokeAsync("setOpacity", opacity);
+        }
+
+        /// <summary>
+        /// The opacity of the overlay, expressed as a number between 0 and 1. Optional. Defaults to 1.
+        /// </summary>
+        /// <param name="opacity"></param>
+        /// <returns></returns>
+        public async Task SetOpacity(decimal opacity)
+        {
+            await SetOpacity(Convert.ToDouble(opacity));
+        }
+
+
+        public void Dispose()
+        {
+            _jsObjectRef?.Dispose();
+        }
     }
 }

--- a/GoogleMapsComponents/Maps/Map.cs
+++ b/GoogleMapsComponents/Maps/Map.cs
@@ -47,6 +47,19 @@ namespace GoogleMapsComponents.Maps
             await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("googleMapsObjectManager.addControls", this.Guid.ToString(), position, reference);
         }
 
+        public async Task AddImageLayer(ImageMapType reference)
+        {
+            await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("googleMapsObjectManager.addImageLayer", this.Guid.ToString(), reference.Guid.ToString());
+        }
+        public async Task RemoveImageLayer(ImageMapType reference)
+        {
+            await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("googleMapsObjectManager.removeImageLayer", this.Guid.ToString(), reference.Guid.ToString());
+        }
+        public async Task RemoveAllImageLayers()
+        {
+            await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("googleMapsObjectManager.removeAllImageLayers", this.Guid.ToString());
+        }
+
         public void Dispose()
         {
             JsObjectRefInstances.Remove(_jsObjectRef.Guid.ToString());

--- a/ServerSideDemo/Pages/MapImageOverlay.razor
+++ b/ServerSideDemo/Pages/MapImageOverlay.razor
@@ -1,0 +1,352 @@
+﻿@page "/mapImageOverlay"
+@using GoogleMapsComponents
+@using GoogleMapsComponents.Maps
+@using System.Diagnostics
+
+<h1>Map Events</h1>
+
+<GoogleMap @ref="@map1" Id="map1" Options="@mapOptions" OnAfterInit="@OnAfterInitAsync">
+</GoogleMap>
+
+Overlay Opacity: <input type="range" min="0" max="1" step="0.1" @bind="LayerOpacity" />
+<br/>
+<button @onclick="AddMarker">Add marker</button>&nbsp;
+<button @onclick="RemoveMarker">Remove marker</button>
+<br>
+<input type="checkbox" bind="@DisablePoiInfoWindow" />Disable POI's popup info window
+<br>
+
+<MapEventList @ref="@eventList" Events="@_events"></MapEventList>
+
+@code {
+    private GoogleMap map1;
+    private MapEventList eventList;
+
+    private MapOptions mapOptions;
+    ImageMapType overlayImage;
+    float layerOpacity = 0.5f;
+    private float LayerOpacity { get => layerOpacity;
+        set
+        {
+            overlayImage.SetOpacity(value);
+            layerOpacity = value;
+        }
+    }
+
+    private List<String> _events = new List<String>();
+
+    private bool DisablePoiInfoWindow { get; set; } = false;
+
+    private Stack<Marker> markers = new Stack<Marker>();
+    private string labelText = "";
+
+    protected override void OnInitialized()
+    {
+        mapOptions = new MapOptions()
+        {
+            Zoom = 13,
+            Center = new LatLngLiteral()
+            {
+                Lat = 13.505892,
+                Lng = 100.8162
+            },
+            MapTypeId = MapTypeId.Roadmap
+        };
+    }
+
+    private async Task OnAfterInitAsync()
+    {
+        //Debug.WriteLine("Start OnAfterRenderAsync");
+
+        await map1.InteropObject.AddListener("bounds_changed", OnBoundsChanged);
+
+        await map1.InteropObject.AddListener("center_changed", OnCenterChanged);
+
+        await map1.InteropObject.AddListener<MouseEvent>("click", async (e) => await OnClick(e));
+
+        await map1.InteropObject.AddListener("dblclick", OnDoubleClick);
+
+        await map1.InteropObject.AddListener("drag", OnDrag);
+
+        await map1.InteropObject.AddListener("dragend", OnDragEnd);
+
+        await map1.InteropObject.AddListener("dragstart", OnDragStart);
+
+        await map1.InteropObject.AddListener("heading_changed", OnHeadingChanged);
+
+        await map1.InteropObject.AddListener("idle", OnIdle);
+
+        await map1.InteropObject.AddListener("maptypeid_changed", OnMapTypeIdChanged);
+
+        await map1.InteropObject.AddListener<MouseEvent>("mousemove", OnMouseMove);
+        await map1.InteropObject.AddListener<MouseEvent>("mousedown", OnMouseMove);
+
+        await map1.InteropObject.AddListener("mouseout", OnMouseOut);
+
+        await map1.InteropObject.AddListener("mouseover", OnMouseOver);
+
+        await map1.InteropObject.AddListener("projection_changed", OnProjectionChanged);
+
+        await map1.InteropObject.AddListener("rightclick", OnRightClick);
+
+        await map1.InteropObject.AddListener("tilesloaded", OnTilesLoaded);
+
+        await map1.InteropObject.AddListener("tilt_changed", OnTiltChanged);
+
+        await map1.InteropObject.AddListener("zoom_changed", OnZoomChanged);
+
+        overlayImage = await ImageMapType.CreateAsync(map1.JsRuntime, "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png", 0, 20, "OSM", 0.75f);
+        await map1.InteropObject?.AddImageLayer(overlayImage);
+    }
+
+    private void OnBoundsChanged()
+    {
+        //Console.WriteLine("Bounds changed.");
+
+        _events.Insert(0, "Bounds changed.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+
+    private void OnCenterChanged()
+    {
+        //Console.WriteLine("Center changed.");
+
+        _events.Insert(0, "Center changed.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+
+    private async Task OnClick(MouseEvent e)
+    {
+        //Console.WriteLine("Click.");
+
+        _events.Insert(0, $"Click {e.LatLng}.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+
+        if (DisablePoiInfoWindow)
+        {
+            await e.Stop();
+        }
+    }
+
+    private void OnDoubleClick()
+    {
+        //Console.WriteLine("Double click.");
+
+        _events.Insert(0, "Double click.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+
+    private void OnDrag()
+    {
+        //Console.WriteLine("Drag.");
+
+        _events.Insert(0, "Drag.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+
+    private void OnDragEnd()
+    {
+        //Console.WriteLine("Drag end.");
+
+        _events.Insert(0, "Drag end.");
+
+        StateHasChanged();
+    }
+
+    private void OnDragStart()
+    {
+        //Console.WriteLine("Drag start.");
+
+        _events.Insert(0, "Drag start.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+
+    private void OnHeadingChanged()
+    {
+        //Console.WriteLine("Heading changed.");
+
+        _events.Insert(0, "Heading changed.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+
+    private void OnIdle()
+    {
+        //Console.WriteLine("Idle.");
+
+        _events.Insert(0, "Idle.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+
+    private void OnMapTypeIdChanged()
+    {
+        //Console.WriteLine("OnMapTypeIdChanged.");
+
+        _events.Insert(0, "OnMapTypeIdChanged.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+
+    private void OnMouseMove(MouseEvent e)
+    {
+        //Console.WriteLine("OnMouseMove.");
+
+        _events.Insert(0, $"OnMouseMove {e.LatLng}.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+
+    private void OnMouseOut()
+    {
+        //Console.WriteLine("OnMouseOut.");
+
+        _events.Insert(0, "OnMouseOut.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+
+    private void OnMouseOver()
+    {
+        //Console.WriteLine("OnMouseOver.");
+
+        _events.Insert(0, "OnMouseOver.");
+
+        StateHasChanged();
+    }
+
+    private void OnProjectionChanged()
+    {
+        //Console.WriteLine("OnProjectionChanged.");
+
+        _events.Insert(0, "OnProjectionChanged.");
+
+        StateHasChanged();
+    }
+
+    private void OnRightClick()
+    {
+        //Console.WriteLine("OnRightClick.");
+
+        _events.Insert(0, "OnRightClick.");
+
+        StateHasChanged();
+    }
+
+    private void OnTilesLoaded()
+    {
+        //Console.WriteLine("OnTilesLoaded.");
+
+        _events.Insert(0, "OnTilesLoaded.");
+
+        StateHasChanged();
+    }
+
+    private void OnTiltChanged()
+    {
+        //Console.WriteLine("OnTiltChanged.");
+
+        _events.Insert(0, "OnTiltChanged.");
+
+        StateHasChanged();
+    }
+
+    private async void OnZoomChanged()
+    {
+        //Console.WriteLine("OnZoomChanged.");
+        var currentzoom = await map1.InteropObject.GetZoom();
+        //Logger.LogInformation("Zoom result: {_currentzoom}");
+        _events.Insert(0, $"OnZoomChanged {currentzoom} ");
+
+        StateHasChanged();
+    }
+    private async Task AddMarker()
+    {
+        var marker = await Marker.CreateAsync(map1.JsRuntime,
+            new MarkerOptions()
+            {
+                Position = await map1.InteropObject.GetCenter(),
+                Map = map1.InteropObject,
+                Label = new MarkerLabel { Text = $"Test {markers.Count()}", FontWeight = "bold" },
+                Draggable = true,
+                Icon = new Icon()
+                {
+                    Url = "https://developers.google.com/maps/documentation/javascript/examples/full/images/beachflag.png"
+                }
+            //Icon = "https://developers.google.com/maps/documentation/javascript/examples/full/images/beachflag.png"
+        });
+
+        //await marker.SetMap(map1);
+
+        //var map = await marker.GetMap();
+
+        var icon = await marker.GetIcon();
+
+        Console.WriteLine($"Get icon result type is : {icon.Value.GetType()}");
+
+        icon.Switch(
+            s => Console.WriteLine(s),
+            i => Console.WriteLine(i.Url),
+            _ => { });
+
+        //if (map == map1.InteropObject)
+        //{
+        //    Console.WriteLine("Yess");
+        //}
+        //else
+        //{
+        //    Console.WriteLine("Nooo");
+        //}
+
+        markers.Push(marker);
+        labelText = await marker.GetLabelText();
+
+        await marker.AddListener<MouseEvent>("click", async e =>
+        {
+            string markerLabelText = await marker.GetLabelText();
+            _events.Add("click on " + markerLabelText);
+            StateHasChanged();
+            await e.Stop();
+        });
+        await marker.AddListener<MouseEvent>("dragend", async e => await OnMakerDragEnd(marker, e));
+    }
+
+    private async Task OnMakerDragEnd(Marker M, MouseEvent e)
+    {
+        string markerLabelText = await M.GetLabelText();
+        _events.Insert(0, $"OnMakerDragEnd ({markerLabelText}): ({e.LatLng}).");
+        StateHasChanged();
+        await e.Stop();
+    }
+
+    private async Task RemoveMarker()
+    {
+        if (!markers.Any())
+        {
+            return;
+        }
+
+        var lastMarker = markers.Pop();
+        await lastMarker.SetMap(null);
+        labelText = markers.Any() ? await markers.Peek().GetLabelText() : "";
+    }
+
+
+}

--- a/ServerSideDemo/Pages/_Host.cshtml
+++ b/ServerSideDemo/Pages/_Host.cshtml
@@ -20,7 +20,7 @@
 
     <script src="_framework/blazor.server.js"></script>
     <script src="https://unpkg.com/@@googlemaps/markerclustererplus/dist/index.min.js"></script>
-    <!--<script src="_content/BlazorGoogleMaps/objectManager.js"></script>-->
+    <script src="_content/BlazorGoogleMaps/js/objectManager.js"></script>
     <script src="js/serverSideScripts.js"></script>
 </body>
 </html>

--- a/ServerSideDemo/Pages/_Host.cshtml
+++ b/ServerSideDemo/Pages/_Host.cshtml
@@ -20,7 +20,7 @@
 
     <script src="_framework/blazor.server.js"></script>
     <script src="https://unpkg.com/@@googlemaps/markerclustererplus/dist/index.min.js"></script>
-    <script src="_content/BlazorGoogleMaps/objectManager.js"></script>
+    <!--<script src="_content/BlazorGoogleMaps/objectManager.js"></script>-->
     <script src="js/serverSideScripts.js"></script>
 </body>
 </html>

--- a/ServerSideDemo/ServerSideDemo.csproj
+++ b/ServerSideDemo/ServerSideDemo.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ServerSideDemo/ServerSideDemo.csproj
+++ b/ServerSideDemo/ServerSideDemo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ServerSideDemo/Shared/NavMenu.razor
+++ b/ServerSideDemo/Shared/NavMenu.razor
@@ -23,6 +23,11 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="mapImageOverlay">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Image Overlay
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="mapEvents">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Events
             </NavLink>


### PR DESCRIPTION
I'm not 100% on if this implementation is imageMapType is good (kinda specific url format), but its a start.  The important part is adding the eval() fallback in the tryParseJson.  This allows us to include functions in the json string we use to initialize the imageMapType.  I also bumped things to .net 5 (even though .net 6 is is out, now) so we could employ js isloation.  I started trying to implement loading of google maps js in the component library, but I ran into CORS issues (what else is new).

+employed js isolation so users don't not have to reference the .js file, themselves.
+Added ImageMapType and supporting js for show/hide layers
Server-side demo changed to .net 5 (for js isolation)
_Host.cshtml removed reference to objectManager.js
"Events" page of server side demo works (Because it uses the GoogleMap root component rather than the Map component)!

