### PR TITLE
make desktop mode sidebar scroll overflow-y

### DIFF
--- a/ServerSideDemo/wwwroot/css/site.css
+++ b/ServerSideDemo/wwwroot/css/site.css
@@ -127,6 +127,7 @@ app {
         height: 100vh;
         position: sticky;
         top: 0;
+        overflow-y: scroll;
     }
 
     .main .top-row {


### PR DESCRIPTION
Desktop sidebar will now scroll instead of extending the page when there are too many items for the screen height. This fixes items rendered below the page being unreadable due to white text on white background with smaller view heights.