### PR TITLE
MarkerList API improvements & use better event in server example

### DIFF
--- a/GoogleMapsComponents/Maps/Extension/MarkerList.cs
+++ b/GoogleMapsComponents/Maps/Extension/MarkerList.cs
@@ -314,6 +314,20 @@ namespace GoogleMapsComponents.Maps.Extension
                 dictArgs);
         }
 
+        /// <summary>
+        /// Set Icon on each Marker matching a param dictionary key to the param value with single JSInterop call.
+        /// </summary>
+        /// <param name="icons"></param>
+        /// <returns></returns>
+        public Task SetIcons(Dictionary<string, OneOf<string, Icon, Symbol>> icons)
+        {
+            Dictionary<Guid, object> dictArgs = icons.ToDictionary(e => Markers[e.Key].Guid, e => (object)e.Value);
+            return _jsObjectRef.InvokeMultipleAsync(
+                "setIcon",
+                dictArgs);
+        }
+
+        /// <inheritdoc cref="SetIcons(Dictionary{string, OneOf{string, Icon, Symbol}})"/>
         public Task SetIcons(Dictionary<string, string> icons)
         {
             Dictionary<Guid, object> dictArgs = icons.ToDictionary(e => Markers[e.Key].Guid, e => (object)e.Value);
@@ -322,6 +336,7 @@ namespace GoogleMapsComponents.Maps.Extension
                 dictArgs);
         }
 
+        /// <inheritdoc cref="SetIcons(Dictionary{string, OneOf{string, Icon, Symbol}})"/>
         public Task SetIcons(Dictionary<string, Icon> icons)
         {
             Dictionary<Guid, object> dictArgs = icons.ToDictionary(e => Markers[e.Key].Guid, e => (object)e.Value);

--- a/GoogleMapsComponents/Maps/Extension/MarkerList.cs
+++ b/GoogleMapsComponents/Maps/Extension/MarkerList.cs
@@ -330,6 +330,9 @@ namespace GoogleMapsComponents.Maps.Extension
                 dictArgs);
         }
 
+
+        /// <inheritdoc cref="SetLabels(Dictionary{string, OneOf{string, MarkerLabel}})"/>
+        [Obsolete("Use overloads that take string, MarkerLabel, or OneOf<string, MarkerLabel> as dictionary value type.")]
         public Task SetLabels(Dictionary<string, Symbol> labels)
         {
             Dictionary<Guid, object> dictArgs = labels.ToDictionary(e => Markers[e.Key].Guid, e => (object)e.Value);
@@ -337,6 +340,39 @@ namespace GoogleMapsComponents.Maps.Extension
                 "setLabel",
                 dictArgs);
         }
+
+        /// <summary>
+        /// Set Label on each Marker matching a param dictionary key to the param value with single JSInterop call.
+        /// </summary>
+        /// <param name="labels"></param>
+        /// <returns></returns>
+        public Task SetLabels(Dictionary<string, OneOf<string, MarkerLabel>> labels)
+        {
+            Dictionary<Guid, object> dictArgs = labels.ToDictionary(e => Markers[e.Key].Guid, e => (object)e.Value);
+            return _jsObjectRef.InvokeMultipleAsync(
+                "setLabel",
+                dictArgs);
+        }
+
+        /// <inheritdoc cref="SetLabels(Dictionary{string, OneOf{string, MarkerLabel}})"/>
+        public Task SetLabels(Dictionary<string, string> labels)
+        {
+            Dictionary<Guid, object> dictArgs = labels.ToDictionary(e => Markers[e.Key].Guid, e => (object)e.Value);
+            return _jsObjectRef.InvokeMultipleAsync(
+                "setLabel",
+                dictArgs);
+        }
+
+        /// <inheritdoc cref="SetLabels(Dictionary{string, OneOf{string, MarkerLabel}})"/>
+        public Task SetLabels(Dictionary<string, MarkerLabel> labels)
+        {
+            Dictionary<Guid, object> dictArgs = labels.ToDictionary(e => Markers[e.Key].Guid, e => (object)e.Value);
+            return _jsObjectRef.InvokeMultipleAsync(
+                "setLabel",
+                dictArgs);
+        }
+
+        
 
         public Task SetOpacities(Dictionary<string, float> opacities)
         {

--- a/ServerSideDemo/Pages/MapMarker.razor.cs
+++ b/ServerSideDemo/Pages/MapMarker.razor.cs
@@ -75,11 +75,11 @@ namespace ServerSideDemo.Pages
             await map1.InteropObject.FitBounds(boundsLiteral, OneOf.OneOf<int, GoogleMapsComponents.Maps.Coordinates.Padding>.FromT0(1));
 
 
-            if (_IdleListenerForMarkerListeners == null)
-                _IdleListenerForMarkerListeners = await map1.InteropObject.AddListener("idle", async () => { await SetMarkerListeners(); });
+            if (_clusteringendListener == null)
+                _clusteringendListener = await _markerClustering.AddListener("clusteringend", async () => { await SetMarkerListeners(); });
         }
 
-        private MapEventListener? _IdleListenerForMarkerListeners;
+        private MapEventListener? _clusteringendListener;
         private List<string>? _listeningLoneMarkerKeys;
         private async Task SetMarkerListeners()
         {
@@ -117,9 +117,9 @@ namespace ServerSideDemo.Pages
             if (_listeningLoneMarkerKeys.Count == markers.Count)
             {
                 _listeningLoneMarkerKeys = null;
-                await _IdleListenerForMarkerListeners.RemoveAsync();
-                _IdleListenerForMarkerListeners.Dispose();
-                _IdleListenerForMarkerListeners = null;
+                await _clusteringendListener.RemoveAsync();
+                _clusteringendListener.Dispose();
+                _clusteringendListener = null;
             }
         }
 


### PR DESCRIPTION
`MarkerList.SetLabels()` was using the wrong value type. Added overloads to match the reference docs: (https://developers.google.com/maps/documentation/javascript/reference/3.47/marker#Marker.setLabel)

Added missing OneOf overloads for `MarkerList.SetIcons()` 

Found an undocumented event in the MarkerClusterer module which is a better logical trigger for the deferred Marker AddListener I added to the server demo. (Open MarkerClusterer issue for adding missing docs: https://github.com/googlemaps/js-markerclusterer/issues/161)