### PR TITLE
fix markerclusterer clearListeners to work with new js-markerclusterer

### DIFF
--- a/GoogleMapsComponents/Maps/MapEventListener.cs
+++ b/GoogleMapsComponents/Maps/MapEventListener.cs
@@ -31,7 +31,7 @@ namespace GoogleMapsComponents.Maps
 
         public async Task RemoveAsync()
         {
-            await _jsObjectRef.InvokeAsync("google.maps.event.removeListener", _jsObjectRef);
+            await _jsObjectRef.InvokeAsync("remove");
             await _jsObjectRef.DisposeAsync();
         }
     }

--- a/GoogleMapsComponents/Maps/MarkerClustering.cs
+++ b/GoogleMapsComponents/Maps/MarkerClustering.cs
@@ -130,8 +130,12 @@ namespace GoogleMapsComponents.Maps
         {
             if (EventListeners.ContainsKey(eventName))
             {
-                await _jsObjectRef.InvokeAsync("clearListeners", eventName);
+                //await _jsObjectRef.InvokeAsync("clearListeners", eventName);
 
+                foreach (MapEventListener listener in EventListeners[eventName])
+                {
+                    await listener.RemoveAsync();
+                }
                 //IMHO is better preserving the knowledge that Marker had some EventListeners attached to "eventName" in the past
                 //so, instead of clearing the list and removing the key from dictionary, I prefer to leave the key with an empty list
                 EventListeners[eventName].Clear();

--- a/ServerSideDemo/Pages/MapMarker.razor.cs
+++ b/ServerSideDemo/Pages/MapMarker.razor.cs
@@ -69,17 +69,16 @@ namespace ServerSideDemo.Pages
 
             _markerClustering = await MarkerClustering.CreateAsync(map1.JsRuntime, map1.InteropObject, markers);
 
+            if (!_markerClustering.EventListeners.ContainsKey("clusteringend") || _markerClustering.EventListeners["clusteringend"].Count == 0)
+                await _markerClustering.AddListener("clusteringend", async () => { await SetMarkerListeners(); });
+
             LatLngBoundsLiteral boundsLiteral = new LatLngBoundsLiteral(new LatLngLiteral() { Lat = coordinates.First().Lat, Lng = coordinates.First().Lng });
             foreach (var literal in coordinates)
                 LatLngBoundsLiteral.CreateOrExtend(ref boundsLiteral, literal);
             await map1.InteropObject.FitBounds(boundsLiteral, OneOf.OneOf<int, GoogleMapsComponents.Maps.Coordinates.Padding>.FromT0(1));
 
-
-            if (_clusteringendListener == null)
-                _clusteringendListener = await _markerClustering.AddListener("clusteringend", async () => { await SetMarkerListeners(); });
         }
 
-        private MapEventListener? _clusteringendListener;
         private List<string>? _listeningLoneMarkerKeys;
         private async Task SetMarkerListeners()
         {
@@ -117,9 +116,7 @@ namespace ServerSideDemo.Pages
             if (_listeningLoneMarkerKeys.Count == markers.Count)
             {
                 _listeningLoneMarkerKeys = null;
-                await _clusteringendListener.RemoveAsync();
-                _clusteringendListener.Dispose();
-                _clusteringendListener = null;
+                await _markerClustering.ClearListeners("clusteringend");
             }
         }
 


### PR DESCRIPTION
In pull request https://github.com/rungwiroon/BlazorGoogleMaps/pull/182, I misunderstood part of the issue with the MapEventListener not removing properly. The console error about a 'remove' function not existing was because the listener object had already been disposed from BlazorGoogleMap's reference dict (or hadn't been added to it), not because there isn't a remove() on the MapEventListener class.

The real source of the problem was that the latest js-markerclusterer doesn't have a clearListeners() function like the old version. Listeners need to be cleared individually/separately. 

This pull request reverts MapEventListener to correctly call remove() as before, and fixes MarkerClusterer.clearListeners() to loop through listeners it's trying to remove. 