### PR TITLE
Implement AddMarkers() and RemoveMarkers in iMarkerClustering

### DIFF
--- a/GoogleMapsComponents/Maps/MarkerClustering.cs
+++ b/GoogleMapsComponents/Maps/MarkerClustering.cs
@@ -102,10 +102,9 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// Removes all clusters and markers from the map and also removes all markers managed by the clusterer.
         /// </summary>
-        public virtual async Task ClearMarkers()
+        public virtual async Task ClearMarkers(bool noDraw = false)
         {
-            await _jsObjectRef.InvokeAsync("clearMarkers");
-            await _jsObjectRef.InvokeAsync("render");
+            await _jsObjectRef.InvokeAsync("clearMarkers", noDraw);
         }
 
         /// <summary>

--- a/GoogleMapsComponents/Maps/MarkerClustering.cs
+++ b/GoogleMapsComponents/Maps/MarkerClustering.cs
@@ -33,7 +33,7 @@ namespace GoogleMapsComponents.Maps
             }
             var guid = System.Guid.NewGuid();
             var jsObjectRef = new JsObjectRef(jsRuntime, guid);
-            await jsRuntime.InvokeVoidAsync("googleMapsObjectManager.addClusteringMarkers", guid.ToString(), map.Guid.ToString(), markers, options);
+            await jsRuntime.InvokeVoidAsync("googleMapsObjectManager.createClusteringMarkers", guid.ToString(), map.Guid.ToString(), markers, options);
             var obj = new MarkerClustering(jsObjectRef, map, markers);
             return obj;
         }
@@ -46,7 +46,15 @@ namespace GoogleMapsComponents.Maps
             EventListeners = new Dictionary<string, List<MapEventListener>>();
         }
 
-        
+        /// <summary>
+        /// Add additional markers to an existing MarkerClusterer
+        /// </summary>
+        /// <param name="noDraw">when true, clusters will not be rerendered on the next map idle event rather than immediately after markers are added</param>
+        public virtual async Task AddMarkers(IEnumerable<Marker> markers, bool noDraw = false)
+        {
+            await _jsObjectRef.JSRuntime.InvokeVoidAsync("googleMapsObjectManager.addClusteringMarkers", _jsObjectRef.Guid.ToString(), markers, noDraw);
+        }
+
         public virtual async Task<MapEventListener> AddListener(string eventName, Action handler)
         {
             JsObjectRef listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync("addListener", eventName, handler);
@@ -81,6 +89,14 @@ namespace GoogleMapsComponents.Maps
         {
             _map = map;
             await _jsObjectRef.InvokeAsync("setMap", map);
+        }
+
+        /// <summary>
+        /// Removes provided markers from the clusterer's internal list of source markers.
+        /// </summary>
+        public virtual async Task RemoveMarkers(IEnumerable<Marker> markers, bool noDraw = false)
+        {
+            await _jsObjectRef.InvokeAsync("removeMarkers", markers, noDraw);
         }
 
         /// <summary>

--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -668,7 +668,7 @@ window.googleMapsObjectManager = {
         return result;
     },
 
-    addClusteringMarkers(guid, mapGuid, markers, options) {
+    createClusteringMarkers(guid, mapGuid, markers, options) {
         const map = window._blazorGoogleMapsObjects[mapGuid];
 
         const originalMarkers = markers.map((marker, i) => {
@@ -701,6 +701,22 @@ window.googleMapsObjectManager = {
         }
 
         window._blazorGoogleMapsObjects[guid] = markerCluster;
+    },
+
+    removeClusteringMarkers(guid, markers, noDraw) {
+        const originalMarkers = markers.map((marker, i) => {
+            return window._blazorGoogleMapsObjects[marker.guid];
+        });
+
+        window._blazorGoogleMapsObjects[guid].addMarkers(originalMarkers, noDraw);
+    },
+
+    addClusteringMarkers(guid, markers, noDraw) {
+        const originalMarkers = markers.map((marker, i) => {
+            return window._blazorGoogleMapsObjects[marker.guid];
+        });
+
+        window._blazorGoogleMapsObjects[guid].addMarkers(originalMarkers, noDraw);
     }
 };
 


### PR DESCRIPTION
Adds missing access to js module functions methods `addMarkers` and `removeMarkers`. Singular item add/remove methods exist but I didn't bother since users can pass an enumerable of length one.

Also added support for the optional `noDraw` parameter to `ClearMarkers()`, and removed the call to `render()` since the underlying `clearMarkers()` function does that automatically when `noDraw` is false (default). 
