### PR TITLE
ZoomOnClick for MarkerClusterer, nullability, and MapPolyline demo

### DIFF
--- a/ClientSideDemoNet5/Pages/MapMarker.razor
+++ b/ClientSideDemoNet5/Pages/MapMarker.razor
@@ -202,7 +202,7 @@
 
         var markers = await GetMarkers(coordinates, map1.InteropObject);
 
-        // initialize markerclusering with an empty marker list if adding a clustering event listener
+        // If adding a clustering event listener, initialize markerclustering with an empty marker list 
         // Clustering happens immediately upon adding markers, so including markers with the init 
         // creates a race condition with JSInterop adding a listener. If not adding a listener, pass markers
         // to CreateAsync to eliminate the latency of a second JSInterop call to AddMarkers.
@@ -210,7 +210,7 @@
         
 
 
-        LatLngBoundsLiteral boundsLiteral = new LatLngBoundsLiteral(new LatLngLiteral() { Lat = coordinates.First().Lat, Lng = coordinates.First().Lng });
+        LatLngBoundsLiteral? boundsLiteral = new LatLngBoundsLiteral(new LatLngLiteral() { Lat = coordinates.First().Lat, Lng = coordinates.First().Lng });
         foreach (var literal in coordinates)
 		    LatLngBoundsLiteral.CreateOrExtend(ref boundsLiteral, literal);
 		

--- a/GoogleMapsComponents/Maps/DirectionsRenderer.cs
+++ b/GoogleMapsComponents/Maps/DirectionsRenderer.cs
@@ -70,7 +70,7 @@ namespace GoogleMapsComponents.Maps
                 "getRouteIndex");
         }
 
-        public async Task SetDirections(DirectionsResult directions)
+        public async Task SetDirections(DirectionsResult? directions)
         {
             await _jsObjectRef.InvokeAsync(
                 "setDirections",
@@ -104,7 +104,7 @@ namespace GoogleMapsComponents.Maps
             }
         }
 
-        public async Task SetMap(Map map)
+        public async Task SetMap(Map? map)
         {
             await _jsObjectRef.InvokeAsync(
                    "setMap",

--- a/GoogleMapsComponents/Maps/ListableEntityBase.cs
+++ b/GoogleMapsComponents/Maps/ListableEntityBase.cs
@@ -53,7 +53,7 @@ namespace GoogleMapsComponents.Maps
         /// If map is set to null, the map entity will be removed.
         /// </summary>
         /// <param name="map"></param>
-        public virtual async Task SetMap(Map map)
+        public virtual async Task SetMap(Map? map)
         {
             await _jsObjectRef.InvokeAsync("setMap", map);
 

--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -676,7 +676,7 @@ window.googleMapsObjectManager = {
         });
 
         const markerClustererOptions = { map: map, markers: originalMarkers };
-        if (!options.ZoomOnClick) {
+        if (options && !options.zoomOnClick) {
             markerClustererOptions.onClusterClick = () => { };
         }
 

--- a/ServerSideDemo/Pages/MapPolyline.razor
+++ b/ServerSideDemo/Pages/MapPolyline.razor
@@ -85,9 +85,12 @@
             }
         });
         await polyline.AddListener("set_at", async () =>
-        {
-            path = (await polyline.GetPath().ConfigureAwait(true)).ToList();
-        });
+      {
+          if (polyline != null)
+          {
+              path = (await polyline.GetPath().ConfigureAwait(true)).ToList();
+          }
+      });
         await polyline.AddListener("remove_at", async () =>
         {
             if (polyline != null)
@@ -106,26 +109,28 @@
 
     private async Task ClearPolylinePath()
     {
-        var line = polylines.FirstOrDefault();
+        var line = polylines.LastOrDefault();
         if (line == null) return;
 
         var polylinePath = await line.CreatePath();
         await polylinePath.Clear();
+
     }
     private async Task AppendToPolylinePath()
     {
-        var line = polylines.FirstOrDefault();
+        var line = polylines.LastOrDefault();
         if (line == null) return;
 
-        var polylinePath = await line.CreatePath();
-        await polylinePath.Push(new LatLngLiteral(98.3256193, 7.8881847));
+        polyline = line;
+        path = (await polyline.GetPath().ConfigureAwait(true)).ToList();
     }
-    private async Task EndDrawingPolyline()
+    private Task EndDrawingPolyline()
     {
         polylines.Add(polyline);
 
         polyline = null;
         path.Clear();
+        return Task.CompletedTask;
     }
 
     private void AddArrowsToPolyline()
@@ -185,12 +190,13 @@
         path.Clear();
     }
 
-    private async Task EndDrawingPolygon()
+    private Task EndDrawingPolygon()
     {
         polygons.Add(polygon);
 
         polygon = null;
         path.Clear();
+        return Task.CompletedTask;
     }
 
     private async Task DrawingRectangle()


### PR DESCRIPTION
ZoomOnClick option was not functional because C# forces json property first char to lower case.

fixes Nullability errors that were preventing compile on Rebuild All

Fixes crash in ServerSideDemo where code attempted to access `polyline` while it is null.