### PR TITLE
Render and algorithm settings for MarkerClustererOptions 

### DIFF
--- a/GoogleMapsComponents/Maps/MarkerClustererOptions.cs
+++ b/GoogleMapsComponents/Maps/MarkerClustererOptions.cs
@@ -98,5 +98,18 @@ namespace GoogleMapsComponents.Maps
         /// and it deals with zooming on its own.
         /// </summary>
         public bool? ZoomOnClick { get; set; }
+
+        /// <summary>
+        /// full js object name in dot notation from window, for the object containing the algorithm function for js-markerclusterer use in calculating clusters. 
+        /// options built-in to js-markerclusterer include "markerClusterer.GridAlgorithm", "markerClusterer.NoopAlgorithm", and "markerClusterer.SuperClusterAlgorithm" (default)
+        /// see: https://googlemaps.github.io/js-markerclusterer/ for latest options.
+        /// </summary>
+        public string? AlgorithmObjectName { get; set; }
+
+        /// <summary>
+        /// full js object name in dot notation from window, for the object containing the render function for js-markerclusterer to use in rendering cluster markers.
+        /// js-markerclusterer only includes one renderer, DefaultRenderer which is a class and would need to be instantiated before it is referenced in this property.
+        /// </summary>
+        public string? RendererObjectName { get; set; }
     }
 }

--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -675,7 +675,37 @@ window.googleMapsObjectManager = {
             return window._blazorGoogleMapsObjects[marker.guid];
         });
 
-        const markerClustererOptions = { map: map, markers: originalMarkers };
+        const markerClustererOptions = {
+            map: map,
+            markers: originalMarkers,
+        };
+
+        if (options && options.rendererObjectName) {
+            const splits = options.rendererObjectName.split(".");
+            try {
+                let renderer = window[splits[0]];
+                for (i = 1; i < splits.length; i++) {
+                    renderer = renderer[splits[i]];
+                }
+                markerClustererOptions.renderer = renderer;
+            } catch (e){
+                console.log(e);
+            }
+        }
+
+        if (options && options.algorithmObjectName) {
+            const splits = options.rendererObjectName.split(".");
+            try {
+                let algorithm = window[splits[0]];
+                for (i = 1; i < splits.length; i++) {
+                    algorithm = renderer[splits[i]];
+                }
+                markerClustererOptions.algorithm = algorithm;
+            } catch (e) {
+                console.log(e);
+            }
+        }
+
         if (options && !options.zoomOnClick) {
             markerClustererOptions.onClusterClick = () => { };
         }
@@ -721,3 +751,46 @@ window.googleMapsObjectManager = {
 };
 
 //export { googleMapsObjectManager }
+
+
+//window.customRendererLib = {
+//    interpolatedRenderer: {
+//        render: function ({ count, position }, stats) {
+//            const color = count > Math.max(5, stats.clusters.markers.mean) ? "#F00" : "#00F";
+
+//            let countText;
+//            try {
+//                let formatter = Intl.NumberFormat('en', { notation: 'compact' });
+//                countText = formatter.format(count);
+//            } catch {
+//                countText = String(count);
+//            }
+
+//            // create svg url with fill color
+//            const svg = window.btoa(`
+//  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+//    <circle cx="120" cy="120" opacity=".1" r="120" fill="#000000"/>
+//    <circle cx="120" cy="120" opacity="1" r="100" fill="#ffffff"/>
+//    <circle cx="120" cy="120" opacity="1" r="64" fill="${color}"/>
+//  </svg>`);
+//            // create marker using svg icon
+//            return new google.maps.Marker({
+//                position,
+//                icon: {
+//                    url: `data:image/svg+xml;base64,${svg}`,
+//                    scaledSize: new google.maps.Size(50, 50),
+//                },
+//                label: {
+//                    text: countText,
+//                    color: "#ffffff",
+//                    fontSize: "16px",
+//                    fontWeight: "bold",
+//                    fontFamily: "Open Sans"
+//                },
+//                // adjust zIndex to be above other markers
+//                zIndex: Number(google.maps.Marker.MAX_ZINDEX) + count,
+//            });
+//        },
+//    }
+//};
+

--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -698,7 +698,7 @@ window.googleMapsObjectManager = {
             try {
                 let algorithm = window[splits[0]];
                 for (i = 1; i < splits.length; i++) {
-                    algorithm = renderer[splits[i]];
+                    algorithm = algorithm[splits[i]];
                 }
                 markerClustererOptions.algorithm = algorithm;
             } catch (e) {

--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -694,7 +694,7 @@ window.googleMapsObjectManager = {
         }
 
         if (options && options.algorithmObjectName) {
-            const splits = options.rendererObjectName.split(".");
+            const splits = options.algorithmObjectName.split(".");
             try {
                 let algorithm = window[splits[0]];
                 for (i = 1; i < splits.length; i++) {

--- a/ServerSideDemo/Pages/MapMarker.razor.cs
+++ b/ServerSideDemo/Pages/MapMarker.razor.cs
@@ -73,7 +73,10 @@ namespace ServerSideDemo.Pages
                 // Clustering happens immediately upon adding markers, so including markers with the init 
                 // creates a race condition with JSInterop adding a listener. If not adding a listener, pass markers
                 // to CreateAsync to eliminate the latency of a second JSInterop call to AddMarkers.
-                _markerClustering = await MarkerClustering.CreateAsync(map1.JsRuntime, map1.InteropObject, new List<Marker>());
+                _markerClustering = await MarkerClustering.CreateAsync(map1.JsRuntime, map1.InteropObject, new List<Marker>(), new MarkerClustererOptions()
+                {
+                    // RendererObjectName = "customRendererLib.interpolatedRenderer"
+                });
                 await _markerClustering.AddListener("clusteringend", async () => { await SetMarkerListeners(); });
             }
             await _markerClustering.AddMarkers(markers);


### PR DESCRIPTION
This makes it possible to set a custom `render` or `algorithm` function via MarkerClustererOptions without needing to host a custom version of `objectManager.js` to set the option when instantiating the `js-markerclusterer` object. 

Example of usage is added to `objectManager.js` and `MapMarker.razor.cs` in ServerSideDemo, but commented out as most people will probably want the defaults. 