### PR TITLE
Bum OneOf from 2.1 to 3.0

### DIFF
--- a/GoogleMapsComponents/GoogleMapsComponents.csproj
+++ b/GoogleMapsComponents/GoogleMapsComponents.csproj
@@ -57,7 +57,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.21" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="OneOf" Version="2.1.151" />
+		<PackageReference Include="OneOf" Version="3.0.223" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bumping OneOf to 3.0 since they have changed reference from NetStandard.Library which contains some vurnable parts. Went through all examples and it did not break anything nor did I have to change anything in the code. 

Unless someone else has a reason this should not be done I think this is something simple and always good to keep the dependencies up to date. 
