### PR TITLE
Fix Polygon.GetPaths JS exception

### DIFF
--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -515,7 +515,22 @@ window.googleMapsObjectManager = {
                 console.log(e);
             }
 
-        } else {
+        } else if (functionToInvoke == "getPaths") {
+            // Polygon.getPaths returns nested MVCArray
+            // https://developers.google.com/maps/documentation/javascript/reference/polygon#Polygon.getPaths
+            try {
+                var paths = obj[functionToInvoke](...args2);
+                var nestedCoords = [];
+                // MVC array
+                paths.forEach(coords => {
+                    nestedCoords.push(coords.getArray());
+                });
+                return nestedCoords;
+            } catch (e) {
+                console.log(e);
+            }
+        }
+        else {
             var result = null;
             try {
                 result = obj[functionToInvoke](...args2);

--- a/ServerSideDemo/Pages/MapPolyline.razor
+++ b/ServerSideDemo/Pages/MapPolyline.razor
@@ -16,6 +16,7 @@
 <button @onclick="StartDrawingPolygon">Start drawing polygon</button>
 <button @onclick="EndDrawingPolygon">End drawing polygon</button>
 <button @onclick="SetAndGetPathPolygon">Set and Get path polygon</button>
+<button @onclick="SetAndGetPolygonPaths">Set and Get polygon paths</button>
 <br />
 <button @onclick="DrawingRectangle">Drawing rectangle</button>
 <br />
@@ -298,4 +299,48 @@
             Console.WriteLine(latLngLiteral);
         }
     }
+
+    // Reference from https://developers.google.com/maps/documentation/javascript/examples/polygon-hole
+    private async Task SetAndGetPolygonPaths()
+    {
+        var outerCoords = new List<LatLngLiteral>()
+        {
+            new LatLngLiteral(13.501908279929077, 100.69801114196777),
+            new LatLngLiteral(13.491392275719202, 100.74933789367675),
+            new LatLngLiteral(13.465851481053091, 100.71637890930175),
+        };
+
+        var innerCoords = new List<LatLngLiteral>()
+        {
+            new LatLngLiteral(13.487386057049033, 100.72633526916503),
+            new LatLngLiteral(13.48137660307361, 100.719125491333),
+            new LatLngLiteral(13.478705686132331, 100.72959683532714),
+        };
+
+        var polygonForPaths = await Polygon.CreateAsync(map1.JsRuntime, new PolygonOptions()
+        {
+            Paths = new[] { outerCoords, innerCoords },
+            Draggable = true,
+            Editable = false,
+            FillColor = "blue",
+            ZIndex = 999,
+        });
+
+        polygons.Add(polygonForPaths);
+        await polygonForPaths.SetMap(map1.InteropObject);
+
+        var polygonPaths = await polygonForPaths.GetPaths();
+        var polygonPathsList = polygonPaths.ToList();
+
+        for (var i = 0; i < polygonPathsList.Count; i++)
+        {
+            Console.WriteLine($"Path: {i}");
+            foreach (var coords in polygonPathsList[i])
+            {
+                Console.WriteLine($"\tLat: {coords.Lat} Lng: {coords.Lng}");
+            }
+        }
+
+    }
+
 }


### PR DESCRIPTION
Currently, `Polygon.GetPaths` produces an exception in JS. This PR will process the nested MVCArray from the Maps API before returning.

Additionally, a demo for Polygon.GetPaths is added based on Google's [Polygon With Hole](https://developers.google.com/maps/documentation/javascript/examples/polygon-hole) .

**The exception**
```
Error: Microsoft.JSInterop.JSException: An exception occurred executing JS interop: The JSON value could not be converted to System.Collections.Generic.IEnumerable`1[GoogleMapsComponents.Maps.LatLngLiteral]. Path: $[0] | LineNumber: 0 | BytePositionInLine: 2.. See InnerException for more details.
 ---> System.Text.Json.JsonException: The JSON value could not be converted to System.Collections.Generic.IEnumerable`1[GoogleMapsComponents.Maps.LatLngLiteral]. Path: $[0] | LineNumber: 0 | BytePositionInLine: 2.
   at System.Text.Json.ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(Type propertyType)
   at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, TCollection& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, TCollection& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCoreAsObject(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadCore[TValue](JsonConverter jsonConverter, Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.JsonSerializer.Read[TValue](Utf8JsonReader& reader, JsonTypeInfo jsonTypeInfo)
   at System.Text.Json.JsonSerializer.Deserialize(Utf8JsonReader& reader, Type returnType, JsonSerializerOptions options)
   at Microsoft.JSInterop.JSRuntime.EndInvokeJS(Int64 taskId, Boolean succeeded, Utf8JsonReader& jsonReader)
   --- End of inner exception stack trace ---
   at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, Object[] args)
   at GoogleMapsComponents.Helper.MyInvokeAsync[TRes](IJSRuntime jsRuntime, String identifier, Object[] args) in C:\[Redacted]\BlazorGoogleMap\GoogleMapsComponents\Helper.cs:line 0
   at ServerSideDemo.Pages.MapPolyline.SetAndGetPolygonPaths() in C:\[Redacted]\BlazorGoogleMap\ServerSideDemo\Pages\MapPolyline.razor:line 332
   at Microsoft.AspNetCore.Components.ComponentBase.CallStateHasChangedOnAsyncCompletion(Task task)
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task taskToHandle, ComponentState owningComponentState) blazor.server.js:1:116274
    log https://localhost:53380/_framework/blazor.server.js:1
    tr https://localhost:53380/_framework/blazor.server.js:1
    er https://localhost:53380/_framework/blazor.server.js:1
    _invokeClientMethod https://localhost:53380/_framework/blazor.server.js:1
    _invokeClientMethod https://localhost:53380/_framework/blazor.server.js:1
    _processIncomingData https://localhost:53380/_framework/blazor.server.js:1
    onreceive https://localhost:53380/_framework/blazor.server.js:1
    onmessage https://localhost:53380/_framework/blazor.server.js:1
```