### PR TITLE
Fixed Data.StyleOptions.FillColor naming

### DIFF
--- a/GoogleMapsComponents/Maps/Data/StyleOptions.cs
+++ b/GoogleMapsComponents/Maps/Data/StyleOptions.cs
@@ -18,23 +18,23 @@ namespace GoogleMapsComponents.Maps.Data
         public string Cursor { get; set; }
 
         /// <summary>
-        /// If true, the object can be dragged across the map and the underlying feature will have its geometry updated. 
+        /// If true, the object can be dragged across the map and the underlying feature will have its geometry updated.
         /// Default value is false.
         /// </summary>
         public bool? Draggable { get; set; }
 
         /// <summary>
-        /// If true, the object can be edited by dragging control points and the underlying feature will have its geometry updated. 
+        /// If true, the object can be edited by dragging control points and the underlying feature will have its geometry updated.
         /// Only applies to LineString and Polygon geometries. Default value is false.
         /// </summary>
         public bool? Editable { get; set; }
 
         /// <summary>
-        /// The fill color. 
-        /// All CSS3 colors are supported except for extended named colors. 
+        /// The fill color.
+        /// All CSS3 colors are supported except for extended named colors.
         /// Only applies to polygon geometries.
         /// </summary>
-        public string Fillcolor { get; set; }
+        public string FillColor { get; set; }
 
         /// <summary>
         /// The fill opacity between 0.0 and 1.0. Only applies to polygon geometries.
@@ -42,51 +42,51 @@ namespace GoogleMapsComponents.Maps.Data
         public float FillOpacity { get; set; }
 
         /// <summary>
-        /// Icon for the foreground. 
-        /// If a string is provided, it is treated as though it were an Icon with the string as url. 
+        /// Icon for the foreground.
+        /// If a string is provided, it is treated as though it were an Icon with the string as url.
         /// Only applies to point geometries.
         /// </summary>
         public OneOf<string, Icon, Symbol>? Icon { get; set; }
 
         /// <summary>
-        /// Defines the image map used for hit detection. 
+        /// Defines the image map used for hit detection.
         /// Only applies to point geometries.
         /// </summary>
         public MarkerShape Shape { get; set; }
 
         /// <summary>
-        /// The stroke color. 
-        /// All CSS3 colors are supported except for extended named colors. 
+        /// The stroke color.
+        /// All CSS3 colors are supported except for extended named colors.
         /// Only applies to line and polygon geometries.
         /// </summary>
         public string StrokeColor { get; set; }
 
         /// <summary>
-        /// The stroke opacity between 0.0 and 1.0. 
+        /// The stroke opacity between 0.0 and 1.0.
         /// Only applies to line and polygon geometries.
         /// </summary>
         public float? StrokeOpacity { get; set; }
 
         /// <summary>
-        /// The stroke width in pixels. 
+        /// The stroke width in pixels.
         /// Only applies to line and polygon geometries.
         /// </summary>
         public float? StrokeWeight { get; set; }
 
         /// <summary>
-        /// Rollover text. 
+        /// Rollover text.
         /// Only applies to point geometries.
         /// </summary>
         public string Title { get; set; }
 
         /// <summary>
-        /// Whether the feature is visible. 
+        /// Whether the feature is visible.
         /// Defaults to true.
         /// </summary>
         public bool? Visible { get; set; }
 
         /// <summary>
-        /// All features are displayed on the map in order of their zIndex, with higher values displaying in front of features with lower values. 
+        /// All features are displayed on the map in order of their zIndex, with higher values displaying in front of features with lower values.
         /// Markers are always displayed in front of line-strings and polygons.
         /// </summary>
         public int ZIndex { get; set; }

--- a/ServerSideDemo/Pages/MapDataPage.razor
+++ b/ServerSideDemo/Pages/MapDataPage.razor
@@ -11,7 +11,8 @@
 
 <GoogleMap @ref="@(this._map1)" Id="map1" Options="@(this._mapOptions)" OnAfterInit="async () => await OnAfterMapInit()"></GoogleMap>
 <button @onclick="@GetMapDataFeature">Get MapData (Feature)</button>
-<button @onclick="@GetMapDataGeoJson">Get MapData (GeoJson)</button>
+<button @onclick="@GetMapDataGeoJsonLine">Get MapData (GeoJson Line)</button>
+<button @onclick="@GetMapDataGeoJsonPolygon">Get MapData (GeoJson Polygon)</button>
 <button @onclick="@RemoveFeatures">Remove All Features</button>
 
 <div>
@@ -89,7 +90,7 @@
         await _map1.InteropObject.Data.SetStyle(new StyleOptions { StrokeColor = "blue", StrokeWeight = 2 });
     }
 
-    private async Task GetMapDataGeoJson()
+    private async Task GetMapDataGeoJsonLine()
     {
         var jsonData = "{ \"type\": \"FeatureCollection\"," +
                        "  \"features\": [" +
@@ -100,6 +101,19 @@
 
         await _map1.InteropObject.Data.AddGeoJson(jsonData);
         await _map1.InteropObject.Data.SetStyle(new StyleOptions { StrokeColor = "green", StrokeWeight = 2 });
+    }
+
+    private async Task GetMapDataGeoJsonPolygon()
+    {
+        var jsonData = "{ \"type\": \"FeatureCollection\"," +
+                       "  \"features\": [" +
+                       "{ \"type\": \"Feature\"," +
+                       " \"id\": 3," +
+                       " \"properties\": { \"stroke\": \"#555555\", \"stroke-width\": 2, \"stroke-opacity\": 1 }, " +
+                       " \"geometry\": {\"type\": \"Polygon\",  \"coordinates\": [ [ [ 151.219, -33.888], [151.23, -33.888], [151.23, -33.869], [ 151.219, -33.869], [ 151.219, -33.888]]]}}]}";
+
+        await _map1.InteropObject.Data.AddGeoJson(jsonData);
+        await _map1.InteropObject.Data.SetStyle(new StyleOptions { StrokeColor = "magenta", StrokeWeight = 2, FillColor = "magenta", FillOpacity = 0.3f });
     }
 
     private async Task RemoveFeatures()


### PR DESCRIPTION
Fixed naming of Data.StyleOptions.FillColor (was previously `Fillcolor`, which was ignored by GoogleMaps javascript API because of case-sensitivity).  Added a demonstration in the MapData page to load (and fill-in!) a GeoJson polygon.