### PR TITLE
Support custom js marker constructor

### DIFF
--- a/GoogleMapsComponents/Maps/Marker.cs
+++ b/GoogleMapsComponents/Maps/Marker.cs
@@ -13,6 +13,13 @@ namespace GoogleMapsComponents.Maps
             return obj;
         }
 
+        public static async Task<Marker> CreateAsync(IJSRuntime jsRuntime, string? jsConstructor, MarkerOptions? opts = null)
+        {
+            var jsObjectRef = await JsObjectRef.CreateAsync(jsRuntime, jsConstructor ?? "google.maps.Marker", opts);
+            var obj = new Marker(jsObjectRef);
+            return obj;
+        }
+
         internal Marker(JsObjectRef jsObjectRef)
             : base(jsObjectRef)
         {


### PR DESCRIPTION
Today we have to use reflection to be able to construct a MarkerWithLabel. Here is a example of what we do:
![image](https://user-images.githubusercontent.com/54627464/220662378-1b0559bf-be7f-4d94-94c4-83506e18d98a.png)

This adds a new method on marker allowing the user specify what js constructor to use. If it's off intrest I could add a example for it later.

Note: I'm not completely sure that calling it jsConstructor is the best but I feel like it fits for what it does in my case atleast.