### PR TITLE
enum serialization for StrokePosition and SymbolPath

### DIFF
--- a/GoogleMapsComponents/Maps/CircleOptions.cs
+++ b/GoogleMapsComponents/Maps/CircleOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace GoogleMapsComponents.Maps
+﻿using System.Text.Json.Serialization;
+
+namespace GoogleMapsComponents.Maps
 {
     /// <summary>
     /// CircleOptions object used to define the properties that can be set on a Circle.
@@ -47,6 +49,7 @@
         /// The stroke position. Defaults to CENTER. 
         /// This property is not supported on Internet Explorer 8 and earlier.
         /// </summary>
+        [JsonConverter(typeof(EnumMemberConverter<StrokePosition>))]
         public StrokePosition? StrokePosition { get; set; }
 
         /// <summary>

--- a/GoogleMapsComponents/Maps/MapTypeId.cs
+++ b/GoogleMapsComponents/Maps/MapTypeId.cs
@@ -29,7 +29,7 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// This map type displays maps with physical features such as terrain and vegetation.
         /// </summary>
-        [EnumMember(Value = "rerrain")]
+        [EnumMember(Value = "terrain")]
         Terrain
     }
 }

--- a/GoogleMapsComponents/Maps/PolygonOptions.cs
+++ b/GoogleMapsComponents/Maps/PolygonOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace GoogleMapsComponents.Maps
 {
@@ -55,6 +56,7 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// The stroke position. Defaults to CENTER. This property is not supported on Internet Explorer 8 and earlier.
         /// </summary>
+        [JsonConverter(typeof(EnumMemberConverter<StrokePosition>))]
         public StrokePosition StrokePosition { get; set; }
 
         /// <summary>

--- a/GoogleMapsComponents/Maps/RectangleOptions.cs
+++ b/GoogleMapsComponents/Maps/RectangleOptions.cs
@@ -59,6 +59,7 @@ namespace GoogleMapsComponents.Maps
         /// Defaults to CENTER. 
         /// This property is not supported on Internet Explorer 8 and earlier.
         /// </summary>
+        [JsonConverter(typeof(EnumMemberConverter<StrokePosition>))]
         public StrokePosition? StrokePosition { get; set; }
 
         /// <summary>

--- a/GoogleMapsComponents/Maps/StrokePosition.cs
+++ b/GoogleMapsComponents/Maps/StrokePosition.cs
@@ -1,9 +1,14 @@
-﻿namespace GoogleMapsComponents.Maps
+﻿using System.Runtime.Serialization;
+
+namespace GoogleMapsComponents.Maps
 {
     public enum StrokePosition
     {
-        Center,
-        Inside,
-        Outside
+        [EnumMember(Value = "0")]
+        Center = 0,
+        [EnumMember(Value = "1")]
+        Inside = 1,
+        [EnumMember(Value = "2")]
+        Outside = 2,
     }
 }

--- a/GoogleMapsComponents/Maps/SymbolPath.cs
+++ b/GoogleMapsComponents/Maps/SymbolPath.cs
@@ -1,4 +1,6 @@
-﻿namespace GoogleMapsComponents.Maps
+﻿using System.Runtime.Serialization;
+
+namespace GoogleMapsComponents.Maps
 {
     /// <summary>
     /// Built-in symbol paths.
@@ -8,26 +10,31 @@
         /// <summary>
         /// A backward-pointing closed arrow.
         /// </summary>
+        [EnumMember(Value = "3")]
         BACKWARD_CLOSED_ARROW = 3,
 
         /// <summary>
         /// A backward-pointing open arrow.
         /// </summary>
+        [EnumMember(Value = "4")]
         BACKWARD_OPEN_ARROW = 4,
 
         /// <summary>
         /// A circle.
         /// </summary>
+        [EnumMember(Value = "0")]
         CIRCLE = 0,
 
         /// <summary>
         /// A forward-pointing closed arrow.
         /// </summary>
+        [EnumMember(Value = "1")]
         FORWARD_CLOSED_ARROW = 1,
 
         /// <summary>
         /// A forward-pointing open arrow.
         /// </summary>
+        [EnumMember(Value = "2")]
         FORWARD_OPEN_ARROW = 2
     }
 }


### PR DESCRIPTION
Serializing these enums as strings (e.g. "CIRCLE" and "Center") either breaks the constructor in objectManager.createObject() or causes a `TypeError: h[r] is not a function` error during drawing.

Can be checked with the polyline and drawing manager demo pages.  