### PR TITLE
Added support for AddListenerOnce

### DIFF
--- a/GoogleMapsComponents/GoogleMap.razor
+++ b/GoogleMapsComponents/GoogleMap.razor
@@ -79,5 +79,6 @@
         //    foreach (var mi in moduleImports)
         //        await mi.DisposeAsync();
         //}
+        base.Dispose();
     }
 }

--- a/GoogleMapsComponents/Maps/Data.cs
+++ b/GoogleMapsComponents/Maps/Data.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GoogleMapsComponents.Maps.Data;
+using GoogleMapsComponents.Maps.Extension;
 using Microsoft.JSInterop;
 using OneOf;
 
@@ -14,7 +15,7 @@ namespace GoogleMapsComponents.Maps
     /// Every Map has a Data object by default, so most of the time there is no need to construct one.
     /// The Data object is a collection of Features.
     /// </summary>
-    public class MapData : IEnumerable<Maps.Data.Feature>, IDisposable
+    public class MapData : EventEntityBase, IEnumerable<Maps.Data.Feature>, IDisposable
     {
         private readonly JsObjectRef _jsObjectRef;
         private Map _map;
@@ -35,7 +36,7 @@ namespace GoogleMapsComponents.Maps
         /// <summary>
         /// Creates an empty collection, with the given DataOptions.
         /// </summary>
-        internal MapData(JsObjectRef jsObjectRef)
+        internal MapData(JsObjectRef jsObjectRef) : base(jsObjectRef)
         {
             _jsObjectRef = jsObjectRef;
         }
@@ -312,22 +313,6 @@ namespace GoogleMapsComponents.Maps
         public Task<object> ToGeoJson()
         {
             throw new NotImplementedException();
-        }
-
-        public async Task<MapEventListener> AddListener(string eventName, Action handler)
-        {
-            var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
-                "addListener", eventName, handler);
-
-            return new MapEventListener(listenerRef);
-        }
-
-        public async Task<MapEventListener> AddListener<T>(string eventName, Action<T> handler)
-        {
-            var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
-                "addListener", eventName, handler);
-
-            return new MapEventListener(listenerRef);
         }
     }
 }

--- a/GoogleMapsComponents/Maps/Data.cs
+++ b/GoogleMapsComponents/Maps/Data.cs
@@ -41,8 +41,9 @@ namespace GoogleMapsComponents.Maps
             _jsObjectRef = jsObjectRef;
         }
 
-        public void Dispose()
+        public new void Dispose()
         {
+            base.Dispose();
             _jsObjectRef.Dispose();
         }
 

--- a/GoogleMapsComponents/Maps/DirectionsRenderer.cs
+++ b/GoogleMapsComponents/Maps/DirectionsRenderer.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.JSInterop;
 using System;
 using System.Threading.Tasks;
+using GoogleMapsComponents.Maps.Extension;
 
 namespace GoogleMapsComponents.Maps
 {
-    public class DirectionsRenderer : IDisposable
+    public class DirectionsRenderer : EventEntityBase, IDisposable
     {
         private readonly JsObjectRef _jsObjectRef;
 
@@ -16,7 +17,7 @@ namespace GoogleMapsComponents.Maps
             return obj;
         }
 
-        private DirectionsRenderer(JsObjectRef jsObjectRef)
+        private DirectionsRenderer(JsObjectRef jsObjectRef) : base(jsObjectRef)
         {
             _jsObjectRef = jsObjectRef;
         }
@@ -114,22 +115,5 @@ namespace GoogleMapsComponents.Maps
                 "setRouteIndex",
                 routeIndex);
         }
-
-        public async Task<MapEventListener> AddListener(string eventName, Action handler)
-        {
-            var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
-                "addListener", eventName, handler);
-
-            return new MapEventListener(listenerRef);
-        }
-
-        public async Task<MapEventListener> AddListener<T>(string eventName, Action<T> handler)
-        {
-            var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
-                "addListener", eventName, handler);
-
-            return new MapEventListener(listenerRef);
-        }
-
     }
 }

--- a/GoogleMapsComponents/Maps/DirectionsRenderer.cs
+++ b/GoogleMapsComponents/Maps/DirectionsRenderer.cs
@@ -22,8 +22,9 @@ namespace GoogleMapsComponents.Maps
             _jsObjectRef = jsObjectRef;
         }
 
-        public void Dispose()
+        public new void Dispose()
         {
+            base.Dispose();
             _jsObjectRef?.Dispose();
         }
 

--- a/GoogleMapsComponents/Maps/Drawing/DrawingManager.cs
+++ b/GoogleMapsComponents/Maps/Drawing/DrawingManager.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.JSInterop;
 using System;
 using System.Threading.Tasks;
+using GoogleMapsComponents.Maps.Extension;
 
 namespace GoogleMapsComponents.Maps.Drawing
 {
@@ -9,7 +10,7 @@ namespace GoogleMapsComponents.Maps.Drawing
     /// The DrawingManager's drawing mode defines the type of overlay that will be created by the user. 
     /// Adds a control to the map, allowing the user to switch drawing mode.
     /// </summary>
-    public class DrawingManager : IDisposable
+    public class DrawingManager : EventEntityBase, IDisposable
     {
         private readonly JsObjectRef _jsObjectRef;
         private Map? _map;
@@ -29,7 +30,7 @@ namespace GoogleMapsComponents.Maps.Drawing
         /// <summary>
         /// Creates a DrawingManager that allows users to draw overlays on the map, and switch between the type of overlay to be drawn with a drawing control.
         /// </summary>
-        private DrawingManager(JsObjectRef jsObjectRef, DrawingManagerOptions? opt = null)
+        private DrawingManager(JsObjectRef jsObjectRef, DrawingManagerOptions? opt = null) : base(jsObjectRef)
         {
             _jsObjectRef = jsObjectRef;
 
@@ -39,8 +40,9 @@ namespace GoogleMapsComponents.Maps.Drawing
             }
         }
 
-        public void Dispose()
+        public new void Dispose()
         {
+            base.Dispose();
             _jsObjectRef.Dispose();
         }
 
@@ -100,14 +102,6 @@ namespace GoogleMapsComponents.Maps.Drawing
                    options);
         }
 
-        public async Task<MapEventListener> AddListener(string eventName, Action handler)
-        {
-            var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
-                "addListener", eventName, handler);
-
-            return new MapEventListener(listenerRef);
-        }
-
         public async Task AddOverlayCompleteListener(Action<OverlayCompleteEvent> action)
         {
             void Act(OverlaycompleteArgs args)
@@ -143,14 +137,6 @@ namespace GoogleMapsComponents.Maps.Drawing
 
             await _jsObjectRef.JSRuntime.MyInvokeAsync("blazorGoogleMaps.objectManager.drawingManagerOverlaycomplete",
                 new object[] { this._jsObjectRef.Guid.ToString(), (Action<OverlaycompleteArgs>)Act });
-        }
-
-        public async Task<MapEventListener> AddListener<T>(string eventName, Action<T> handler)
-        {
-            var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
-                "addListener", eventName, handler);
-
-            return new MapEventListener(listenerRef);
         }
 
         /// <summary>

--- a/GoogleMapsComponents/Maps/Event.cs
+++ b/GoogleMapsComponents/Maps/Event.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 namespace GoogleMapsComponents.Maps
 {
     
+    [Obsolete("Use addListener instead, see: https://developers.google.com/maps/deprecations?hl=en#googlemapseventadddomlistener_and_googlemapseventadddomlisteneronce_deprecated_on_april_7_2022")]
     public class Event
     {
         private readonly IJSRuntime _jsRuntime;

--- a/GoogleMapsComponents/Maps/Extension/EventEntityBase.cs
+++ b/GoogleMapsComponents/Maps/Extension/EventEntityBase.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace GoogleMapsComponents.Maps.Extension;
+
+public class EventEntityBase
+{
+    private readonly JsObjectRef _jsObjectRef;
+
+    protected EventEntityBase(JsObjectRef jsObjectRef)
+    {
+        _jsObjectRef = jsObjectRef;
+    }
+    //Note: Maybe we want to keep track of events, and make sure that no duplicates are added, or maybe that is up to the user?
+    public async Task<MapEventListener> AddListener(string eventName, Action handler)
+    {
+        var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
+            "addListener", eventName, handler);
+
+        return new MapEventListener(listenerRef);
+    }
+
+    public async Task<MapEventListener> AddListener<T>(string eventName, Action<T> handler)
+    {
+        var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
+            "addListener", eventName, handler);
+
+        return new MapEventListener(listenerRef);
+    }
+    
+    //Note: Might want to wrap the handler with our own handler to make sure that we dispose the event after trigger?
+    public async Task<MapEventListener> AddListenerOnce(string eventName, Action handler)
+    {
+        var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
+            "addListenerOnce", eventName, handler);
+
+        return new MapEventListener(listenerRef);
+    }
+
+    public async Task<MapEventListener> AddListenerOnce<T>(string eventName, Action<T> handler)
+    {
+        var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
+            "addListenerOnce", eventName, handler);
+
+        return new MapEventListener(listenerRef);
+    }
+}

--- a/GoogleMapsComponents/Maps/Extension/EventEntityBase.cs
+++ b/GoogleMapsComponents/Maps/Extension/EventEntityBase.cs
@@ -1,23 +1,39 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace GoogleMapsComponents.Maps.Extension;
 
-public class EventEntityBase
+public abstract class EventEntityBase : IDisposable
 {
     private readonly JsObjectRef _jsObjectRef;
+    private readonly Dictionary<string, List<MapEventListener>> EventListeners;
+
+    private void AddEvent(string eventName, MapEventListener listener)
+    {
+        if (!EventListeners.TryGetValue(eventName, out var collection))
+        {
+            collection = new List<MapEventListener>();
+            EventListeners.Add(eventName, collection);
+        }
+        collection.Add(listener);
+    }
 
     protected EventEntityBase(JsObjectRef jsObjectRef)
     {
         _jsObjectRef = jsObjectRef;
+        EventListeners = new Dictionary<string, List<MapEventListener>>();
     }
-    //Note: Maybe we want to keep track of events, and make sure that no duplicates are added, or maybe that is up to the user?
+    
     public async Task<MapEventListener> AddListener(string eventName, Action handler)
     {
         var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
             "addListener", eventName, handler);
 
-        return new MapEventListener(listenerRef);
+        var eventListener =  new MapEventListener(listenerRef);
+        AddEvent(eventName, eventListener);
+        return eventListener;
     }
 
     public async Task<MapEventListener> AddListener<T>(string eventName, Action<T> handler)
@@ -25,7 +41,9 @@ public class EventEntityBase
         var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
             "addListener", eventName, handler);
 
-        return new MapEventListener(listenerRef);
+        var eventListener =  new MapEventListener(listenerRef);
+        AddEvent(eventName, eventListener);
+        return eventListener;
     }
     
     //Note: Might want to wrap the handler with our own handler to make sure that we dispose the event after trigger?
@@ -34,7 +52,9 @@ public class EventEntityBase
         var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
             "addListenerOnce", eventName, handler);
 
-        return new MapEventListener(listenerRef);
+        var eventListener =  new MapEventListener(listenerRef);
+        AddEvent(eventName, eventListener);
+        return eventListener;
     }
 
     public async Task<MapEventListener> AddListenerOnce<T>(string eventName, Action<T> handler)
@@ -42,6 +62,42 @@ public class EventEntityBase
         var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
             "addListenerOnce", eventName, handler);
 
-        return new MapEventListener(listenerRef);
+        var eventListener =  new MapEventListener(listenerRef);
+        AddEvent(eventName, eventListener);
+        return eventListener;
+    }
+    
+    public async Task ClearListeners(string eventName)
+    {
+        if (EventListeners.TryGetValue(eventName, out var listeners))
+        {
+            foreach (var listener in listeners.Where(listener => !listener.IsRemoved))
+            {
+                await listener.RemoveAsync();
+            }
+
+            //IMHO is better preserving the knowledge that Marker had some EventListeners attached to "eventName" in the past
+            //so, instead to clear the list and remove the key from dictionary, I prefer to leave the key with an empty list
+            EventListeners[eventName].Clear();
+            //EventListeners.Remove(eventName);
+        }
+    }
+        
+    /// <summary>
+    /// This method takes care of disposing the possible event listeners that were added.
+    /// NOTE: It does not dispose the JsObjectRef and uses it to remove listeners
+    /// ENSURE: If you dispose the jsObjectRef that you do it after calling this method, otherwise dont call this at all.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var eventListener in EventListeners.SelectMany(listener => listener.Value))
+        {
+            if (eventListener.IsRemoved) continue;
+            eventListener.Dispose();
+        }
+
+        EventListeners.Clear();
+        //Should this base class be resposible for disposing this?
+        // _jsObjectRef.Dispose();
     }
 }

--- a/GoogleMapsComponents/Maps/GroundOverlay.cs
+++ b/GoogleMapsComponents/Maps/GroundOverlay.cs
@@ -1,15 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GoogleMapsComponents.Maps.Extension;
 using Microsoft.JSInterop;
 
 namespace GoogleMapsComponents.Maps
 {
-    public class GroundOverlay : IDisposable, IJsObjectRef
+    public class GroundOverlay : EventEntityBase, IDisposable, IJsObjectRef
     {
         private readonly JsObjectRef _jsObjectRef;
-
-        public readonly Dictionary<string, List<MapEventListener>> EventListeners;
 
         public Guid Guid => _jsObjectRef.Guid;
 
@@ -21,24 +20,9 @@ namespace GoogleMapsComponents.Maps
             return obj;
         }
 
-        internal GroundOverlay(JsObjectRef jsObjectRef)
+        internal GroundOverlay(JsObjectRef jsObjectRef) : base (jsObjectRef)
         {
             _jsObjectRef = jsObjectRef;
-            EventListeners = new Dictionary<string, List<MapEventListener>>();
-        }
-
-        public async Task<MapEventListener> AddListener(string eventName, Action handler)
-        {
-            JsObjectRef listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync("addListener", eventName, handler);
-            MapEventListener eventListener = new MapEventListener(listenerRef);
-
-            if (!EventListeners.ContainsKey(eventName))
-            {
-                EventListeners.Add(eventName, new List<MapEventListener>());
-            }
-            EventListeners[eventName].Add(eventListener);
-
-            return eventListener;
         }
 
         /// <summary>
@@ -73,8 +57,9 @@ namespace GoogleMapsComponents.Maps
             //_map = map;
         }
 
-        public void Dispose()
+        public new void Dispose()
         {
+            base.Dispose();
             _jsObjectRef?.Dispose();
         }
     }

--- a/GoogleMapsComponents/Maps/ImageMapType.cs
+++ b/GoogleMapsComponents/Maps/ImageMapType.cs
@@ -2,14 +2,13 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GoogleMapsComponents.Maps.Extension;
 
 namespace GoogleMapsComponents.Maps
 {
-    public class ImageMapType : IDisposable
+    public class ImageMapType : EventEntityBase, IDisposable
     {
         private readonly JsObjectRef _jsObjectRef;
-
-        public readonly Dictionary<string, List<MapEventListener>> EventListeners;
 
         public Guid Guid => _jsObjectRef.Guid;
         public string Name { get; private set; }
@@ -76,24 +75,9 @@ namespace GoogleMapsComponents.Maps
             };
             return to;
         }
-        internal ImageMapType(JsObjectRef jsObjectRef)
+        internal ImageMapType(JsObjectRef jsObjectRef) : base (jsObjectRef)
         {
             _jsObjectRef = jsObjectRef;
-            EventListeners = new Dictionary<string, List<MapEventListener>>();
-        }
-
-        public async Task<MapEventListener> AddListener(string eventName, Action handler)
-        {
-            JsObjectRef listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync("addListener", eventName, handler);
-            MapEventListener eventListener = new MapEventListener(listenerRef);
-
-            if (!EventListeners.ContainsKey(eventName))
-            {
-                EventListeners.Add(eventName, new List<MapEventListener>());
-            }
-            EventListeners[eventName].Add(eventListener);
-
-            return eventListener;
         }
 
         /// <summary>
@@ -127,8 +111,9 @@ namespace GoogleMapsComponents.Maps
         }
 
 
-        public void Dispose()
+        public new void Dispose()
         {
+            base.Dispose();
             _jsObjectRef?.Dispose();
         }
     }

--- a/GoogleMapsComponents/Maps/ListableEntityBase.cs
+++ b/GoogleMapsComponents/Maps/ListableEntityBase.cs
@@ -2,41 +2,25 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GoogleMapsComponents.Maps.Extension;
 
 namespace GoogleMapsComponents.Maps
 {
-    public class ListableEntityBase<TEntityOptions> : IDisposable, IJsObjectRef
+    public class ListableEntityBase<TEntityOptions> : EventEntityBase, IDisposable, IJsObjectRef
         where TEntityOptions : ListableEntityOptionsBase
     {
         protected readonly JsObjectRef _jsObjectRef;
 
-        public readonly Dictionary<string, List<MapEventListener>> EventListeners;
-
         public Guid Guid => _jsObjectRef.Guid;
 
-        internal ListableEntityBase(JsObjectRef jsObjectRef)
+        internal ListableEntityBase(JsObjectRef jsObjectRef) : base(jsObjectRef)
         {
             _jsObjectRef = jsObjectRef;
-            EventListeners = new Dictionary<string, List<MapEventListener>>();
         }
 
-        public void Dispose()
+        public new void Dispose()
         {
-            foreach (string key in EventListeners.Keys)
-            {
-                //Probably superfluous...
-                if ((EventListeners.TryGetValue(key, out var eventsList) && eventsList != null))
-                {
-                    foreach (MapEventListener eventListener in eventsList)
-                    {
-                        eventListener.Dispose();
-                    }
-
-                    eventsList.Clear();
-                }
-            }
-
-            EventListeners.Clear();
+            base.Dispose();
             _jsObjectRef.Dispose();
         }
 
@@ -56,51 +40,6 @@ namespace GoogleMapsComponents.Maps
             await _jsObjectRef.InvokeAsync("setMap", map);
 
             //_map = map;
-        }
-
-        public virtual async Task<MapEventListener> AddListener(string eventName, Action handler)
-        {
-            JsObjectRef listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync("addListener", eventName, handler);
-            MapEventListener eventListener = new MapEventListener(listenerRef);
-
-            if (!EventListeners.ContainsKey(eventName))
-            {
-                EventListeners.Add(eventName, new List<MapEventListener>());
-            }
-            EventListeners[eventName].Add(eventListener);
-
-            return eventListener;
-        }
-
-        public virtual async Task<MapEventListener> AddListener<V>(string eventName, Action<V> handler)
-        {
-            JsObjectRef listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync("addListener", eventName, handler);
-            MapEventListener eventListener = new MapEventListener(listenerRef);
-
-            if (!EventListeners.ContainsKey(eventName))
-            {
-                EventListeners.Add(eventName, new List<MapEventListener>());
-            }
-            EventListeners[eventName].Add(eventListener);
-
-            return eventListener;
-        }
-
-        public virtual async Task ClearListeners(string eventName)
-        {
-            if (EventListeners.TryGetValue(eventName, out var listeners))
-            {
-                foreach (var listener in listeners)
-                {
-                    await listener.RemoveAsync();
-                }
-                //await _jsObjectRef.InvokeAsync("clearListeners", eventName);
-
-                //IMHO is better preserving the knowledge that Marker had some EventListeners attached to "eventName" in the past
-                //so, instead to clear the list and remove the key from dictionary, I prefer to leave the key with an empty list
-                EventListeners[eventName].Clear();
-                //EventListeners.Remove(eventName);
-            }
         }
 
         public Task InvokeAsync(string functionName, params object[] args)

--- a/GoogleMapsComponents/Maps/Map.cs
+++ b/GoogleMapsComponents/Maps/Map.cs
@@ -4,6 +4,7 @@ using Microsoft.JSInterop;
 using OneOf;
 using System;
 using System.Threading.Tasks;
+using GoogleMapsComponents.Maps.Extension;
 
 #nullable enable
 
@@ -13,7 +14,7 @@ namespace GoogleMapsComponents.Maps
     /// google.maps.Map class
     /// </summary>
     //[JsonConverter(typeof(JsObjectRefConverter<Map>))]
-    public class Map : IDisposable, IJsObjectRef
+    public class Map : EventEntityBase, IDisposable, IJsObjectRef
     {
         private readonly JsObjectRef _jsObjectRef;
 
@@ -36,7 +37,7 @@ namespace GoogleMapsComponents.Maps
             return map;
         }
 
-        private Map(JsObjectRef jsObjectRef, MapData data)
+        private Map(JsObjectRef jsObjectRef, MapData data) : base(jsObjectRef)
         {
             _jsObjectRef = jsObjectRef;
             Data = data;
@@ -227,22 +228,6 @@ namespace GoogleMapsComponents.Maps
         public Task SetOptions(MapOptions mapOptions)
         {
             return _jsObjectRef.InvokeAsync("setOptions", mapOptions);
-        }
-
-        public async Task<MapEventListener> AddListener(string eventName, Action handler)
-        {
-            var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
-                "addListener", eventName, handler);
-
-            return new MapEventListener(listenerRef);
-        }
-
-        public async Task<MapEventListener> AddListener<T>(string eventName, Action<T> handler)
-        {
-            var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
-                "addListener", eventName, handler);
-
-            return new MapEventListener(listenerRef);
         }
     }
 }

--- a/GoogleMapsComponents/Maps/Map.cs
+++ b/GoogleMapsComponents/Maps/Map.cs
@@ -61,8 +61,9 @@ namespace GoogleMapsComponents.Maps
             await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("blazorGoogleMaps.objectManager.removeAllImageLayers", this.Guid.ToString());
         }
 
-        public void Dispose()
+        public new void Dispose()
         {
+            base.Dispose();
             JsObjectRefInstances.Remove(_jsObjectRef.Guid.ToString());
             _jsObjectRef.JSRuntime.InvokeAsync<object>("blazorGoogleMaps.objectManager.disposeMapElements", Guid.ToString());
             _jsObjectRef.Dispose();

--- a/GoogleMapsComponents/Maps/MapEventListener.cs
+++ b/GoogleMapsComponents/Maps/MapEventListener.cs
@@ -10,6 +10,7 @@ namespace GoogleMapsComponents.Maps
     public class MapEventListener : IJsObjectRef, IDisposable
     {
         private readonly JsObjectRef _jsObjectRef;
+        public bool IsRemoved = false;
 
         internal MapEventListener(JsObjectRef jsObjectRef)
         {
@@ -30,6 +31,7 @@ namespace GoogleMapsComponents.Maps
         {
             await _jsObjectRef.InvokeAsync("remove");
             await _jsObjectRef.DisposeAsync();
+            IsRemoved = true;
         }
     }
 }

--- a/GoogleMapsComponents/Maps/Places/Autocomplete.cs
+++ b/GoogleMapsComponents/Maps/Places/Autocomplete.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GoogleMapsComponents.Maps.Extension;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 
 namespace GoogleMapsComponents.Maps.Places
 {
-    public class Autocomplete : IDisposable
+    public class Autocomplete : EventEntityBase, IDisposable
     {
         private readonly JsObjectRef _jsObjectRef;
 
@@ -18,7 +19,7 @@ namespace GoogleMapsComponents.Maps.Places
             return obj;
         }
 
-        private Autocomplete(JsObjectRef jsObjectRef)
+        private Autocomplete(JsObjectRef jsObjectRef) : base (jsObjectRef)
         {
             _jsObjectRef = jsObjectRef;
         }
@@ -93,14 +94,6 @@ namespace GoogleMapsComponents.Maps.Places
         public Task SetTypes(IEnumerable<string> types)
         {
             return _jsObjectRef.InvokeAsync("setTypes", types);
-        }
-
-        public async Task<MapEventListener> AddListener(string eventName, Action handler)
-        {
-            var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
-                "addListener", eventName, handler);
-
-            return new MapEventListener(listenerRef);
         }
     }
 }

--- a/GoogleMapsComponents/Maps/Places/Autocomplete.cs
+++ b/GoogleMapsComponents/Maps/Places/Autocomplete.cs
@@ -24,8 +24,9 @@ namespace GoogleMapsComponents.Maps.Places
             _jsObjectRef = jsObjectRef;
         }
 
-        public void Dispose()
+        public new void Dispose()
         {
+            base.Dispose();
             _jsObjectRef?.Dispose();
         }
 

--- a/GoogleMapsComponents/Maps/Rectangle.cs
+++ b/GoogleMapsComponents/Maps/Rectangle.cs
@@ -38,8 +38,9 @@ namespace GoogleMapsComponents.Maps
             _map = opts?.Map;
         }
 
-        public void Dispose()
+        public new void Dispose()
         {
+            base.Dispose();
             _jsObjetRef.Dispose();
         }
 

--- a/GoogleMapsComponents/Maps/Rectangle.cs
+++ b/GoogleMapsComponents/Maps/Rectangle.cs
@@ -1,13 +1,14 @@
 ﻿using Microsoft.JSInterop;
 using System;
 using System.Threading.Tasks;
+using GoogleMapsComponents.Maps.Extension;
 
 namespace GoogleMapsComponents.Maps
 {
     /// <summary>
     /// A rectangle overlay.
     /// </summary>
-    public class Rectangle : IDisposable
+    public class Rectangle : EventEntityBase, IDisposable
     {
         public Guid Guid => _jsObjetRef.Guid;
 
@@ -31,7 +32,7 @@ namespace GoogleMapsComponents.Maps
         /// Create a rectangle using the passed RectangleOptions, which specify the bounds and style.
         /// </summary>
         /// <param name="opts"></param>
-        internal Rectangle(JsObjectRef jsObjectRef, RectangleOptions opts = null)
+        internal Rectangle(JsObjectRef jsObjectRef, RectangleOptions opts = null) : base(jsObjectRef)
         {
             _jsObjetRef = jsObjectRef;
             _map = opts?.Map;
@@ -153,22 +154,6 @@ namespace GoogleMapsComponents.Maps
             return _jsObjetRef.InvokeAsync(
                 "setVisible",
                 visible);
-        }
-
-        public async Task<MapEventListener> AddListener(string eventName, Action handler)
-        {
-            var listenerRef = await _jsObjetRef.InvokeWithReturnedObjectRefAsync(
-                "addListener", eventName, handler);
-
-            return new MapEventListener(listenerRef);
-        }
-
-        public async Task<MapEventListener> AddListener<T>(string eventName, Action<T> handler)
-        {
-            var listenerRef = await _jsObjetRef.InvokeWithReturnedObjectRefAsync(
-                "addListener", eventName, handler);
-
-            return new MapEventListener(listenerRef);
         }
     }
 }

--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -621,9 +621,6 @@
                         if ("addListener" == functionToInvoke) {
                             return result;
                         }
-                        if (functionToInvoke == "remove") {
-                            delete mapObjects[args[0]]; //Clean up the object
-                        }
                         if ("get" in result) {
                             return result.get("guidString");
                         } else if ("dotnetTypeName" in result) {
@@ -631,6 +628,8 @@
                         } else {
                             return JSON.parse(JSON.stringify(result, getCircularReplacer()));
                         }
+                    } else if (functionToInvoke === "remove") {
+                        this.disposeObject(args[0]);
                     } else {
                         return result;
                     }

--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -528,6 +528,10 @@
                         console.log(e);
                     }
                 }
+                else if (functionToInvoke === "addListenerOnce") {
+                    const eventId = new google.maps.event.addListenerOnce(obj, args2[0], args2[1]);
+                    return eventId;
+                }
                 else if (google.maps.places !== undefined && obj instanceof google.maps.places.AutocompleteService) {
                     //AutocompleteService predictions to handle callbacks in the promise
                     return new Promise(function (resolve, reject) {

--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -621,6 +621,9 @@
                         if ("addListener" == functionToInvoke) {
                             return result;
                         }
+                        if (functionToInvoke == "remove") {
+                            delete mapObjects[args[0]]; //Clean up the object
+                        }
                         if ("get" in result) {
                             return result.get("guidString");
                         } else if ("dotnetTypeName" in result) {

--- a/ServerSideDemo/Pages/MapEvents.razor
+++ b/ServerSideDemo/Pages/MapEvents.razor
@@ -47,6 +47,10 @@
         //Debug.WriteLine("Start OnAfterRenderAsync");
 
         await map1.InteropObject.AddListener("bounds_changed", OnBoundsChanged);
+        //Once can be removed before it is triggered, this shows that it is not triggered
+        var reference = await map1.InteropObject.AddListenerOnce("rightclick", OnBoundsChangedOnce);
+        await reference.RemoveAsync();
+        
 
         await map1.InteropObject.AddListener("center_changed", OnCenterChanged);
 
@@ -67,6 +71,9 @@
         await map1.InteropObject.AddListener("maptypeid_changed", OnMapTypeIdChanged);
 
         await map1.InteropObject.AddListener<MouseEvent>("mousemove", OnMouseMove);
+        
+        await map1.InteropObject.AddListenerOnce<MouseEvent>("mousemove", OnMouseMoveOnce);
+        
         await map1.InteropObject.AddListener<MouseEvent>("mousedown", OnMouseMove);
 
         await map1.InteropObject.AddListener("mouseout", OnMouseOut);
@@ -89,6 +96,14 @@
         //Console.WriteLine("Bounds changed.");
 
         _events.Insert(0, "Bounds changed.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+    
+    private void OnBoundsChangedOnce()
+    {
+        _events.Insert(0, "Bounds changed once.");
         _events = _events.Take(100).ToList();
 
         StateHasChanged();
@@ -193,6 +208,16 @@
         //Console.WriteLine("OnMouseMove.");
 
         _events.Insert(0, $"OnMouseMove {e.LatLng}.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+    
+    private void OnMouseMoveOnce(MouseEvent e)
+    {
+        //Console.WriteLine("OnMouseMove.");
+
+        _events.Insert(0, $"OnMouseMoveOnce {e.LatLng.Lat}x{e.LatLng.Lng}.");
         _events = _events.Take(100).ToList();
 
         StateHasChanged();


### PR DESCRIPTION
This adds the ability to only have a event listen once and then never trigger again. Useful for when you want to do something like fixing zoom after idle but not triggering on every idle. 

Not sure about which is the best standard to use for eventListeners since it's somewhat different across the project. As you can see in this [https://github.com/rungwiroon/BlazorGoogleMaps/blob/89e8239ac05cf9c230eaf12e958995542163741f/GoogleMapsComponents/Maps/ListableEntityBase.cs#L61](file) we prevent duplicates, but not in all the places. Added a note in my new base class for the possibility of this. Could be configured per entity type aswell but for now I left those untouched.