### PR TITLE
Add drawingManager suppressUndo undocumented parameter.

### DIFF
--- a/GoogleMapsComponents/Maps/PolylineOptions.cs
+++ b/GoogleMapsComponents/Maps/PolylineOptions.cs
@@ -44,4 +44,11 @@ public class PolylineOptions : ListableEntityOptionsBase
     /// The stroke width in pixels.
     /// </summary>
     public int? StrokeWeight { get; set; }
+
+    /// <summary>    
+    /// Hide the undo button
+    /// Undocuments property.
+    /// </summary>
+    public bool? suppressUndo { get; set; }
+
 }


### PR DESCRIPTION
This PS allows one to hide the undo button in the drawing manager by adding the undocumented suppressUndo parameter to the PolygonOptions class.