### PR TITLE
Handling JSDisconnectedExceptions when disposing map after circuit was disconnected

### DIFF
--- a/GoogleMapsComponents/ExceptionExtensions.cs
+++ b/GoogleMapsComponents/ExceptionExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace GoogleMapsComponents
+{
+    public static class ExceptionExtensions
+    {
+
+
+        public static bool HasInnerExceptionsOfType<T>(this Exception ex) where T : Exception => ex.GetInnerExceptionsOfType<T>().Any();
+
+        public static IEnumerable<T> GetInnerExceptionsOfType<T>(this Exception ex) where T : Exception
+        {
+            var candidates = new[] { ex, ex.InnerException };
+
+            var aggEx = ex as AggregateException;
+            if (aggEx is not null)
+            {
+                var innerEceptions = aggEx?.InnerExceptions?.ToArray() ?? Array.Empty<Exception>();
+                candidates = candidates.Concat(innerEceptions).Where(ex => ex is not null).ToArray();
+
+            }
+            IEnumerable<T> exceptions = candidates.Select(ex => ex as T).Where(ex => ex is not null).Cast<T>().Distinct();
+            return exceptions;
+        }
+    }
+}


### PR DESCRIPTION
e.g. upon page refresh  
Note: Unfortenatly, JSDisconnectedException is available in dotnet >= 6.0, and not in dotnet standard, so esentially all exceptions are swalloed in `MapComponent::DisposeAsyncCore`

Fixes #272 