### PR TITLE
doc(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Migrate from Newtonsoft.Json to System.Text.Json.
 1. Add google map script HEAD tag to wwwroot/index.html in Client side or _Host.cshtml in Server Side.
 How to get key follow https://developers.google.com/maps/documentation/javascript/get-api-key
 
-Do not forgor addition libraries if required *&libraries=places,visualization,drawing*
+Do not forgot addition libraries if required *&libraries=places,visualization,drawing*
 
 If you got 'Loading the Google Maps JavaScript API without a callback is not supported' then add *&callback=Function.prototype*
 ```
@@ -63,7 +63,7 @@ If you want to use marker clustering in a Client Side project then add the follo
 ```
 
 ## Known Issues
-Adding map in razor page without _Host.cshtml use  RenderComponentAsync<T> to render componenent or/and try changing the Rendermode to Server in the host file
+Adding map in razor page without _Host.cshtml use  RenderComponentAsync<T> to render component or/and try changing the Rendermode to Server in the host file
 
 Server Side issue with Route DirectionsResult when using DirectionsRequestOptions all paths are included (all set to false). MaximumReceiveMessageSize reaches limit of 32kb. Then limit should be increased or set to null (unlimited)
 ```


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "forgor" to "forgot" in the README.md file.
 - Corrected "componenent" to "component" in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.