### PR TITLE
Fix #288: Correct typo in draggable method names for Polygon and Rect…

### DIFF
--- a/GoogleMapsComponents/Maps/Polygon.cs
+++ b/GoogleMapsComponents/Maps/Polygon.cs
@@ -46,10 +46,10 @@ public class Polygon : ListableEntityBase<PolygonOptions>
     /// Returns whether this shape can be dragged by the user.
     /// </summary>
     /// <returns></returns>
-    public Task<bool> GetDraggble()
+    public Task<bool> GetDraggable()
     {
         return _jsObjectRef.InvokeAsync<bool>(
-            "getDraggble");
+            "getDraggable");
     }
 
     /// <summary>
@@ -96,12 +96,12 @@ public class Polygon : ListableEntityBase<PolygonOptions>
     /// If set to true, the user can drag this shape over the map. 
     /// The geodesic property defines the mode of dragging.
     /// </summary>
-    /// <param name="draggble"></param>
-    public Task SetDraggble(bool draggble)
+    /// <param name="draggable"></param>
+    public Task SetDraggable(bool draggable)
     {
         return _jsObjectRef.InvokeAsync(
-            "setDraggble",
-            draggble);
+            "setDraggable",
+            draggable);
     }
 
     /// <summary>

--- a/GoogleMapsComponents/Maps/Rectangle.cs
+++ b/GoogleMapsComponents/Maps/Rectangle.cs
@@ -99,12 +99,12 @@ public class Rectangle : EventEntityBase, IDisposable
     /// <summary>
     /// If set to true, the user can drag this rectangle over the map.
     /// </summary>
-    /// <param name="draggble"></param>
-    public Task SetDraggable(bool draggble)
+    /// <param name="draggable"></param>
+    public Task SetDraggable(bool draggable)
     {
         return _jsObjectRef.InvokeAsync(
             "setDraggable",
-            draggble);
+            draggable);
     }
 
     /// <summary>


### PR DESCRIPTION

# Fix Incorrect Draggable Method Names in Polygon and Rectangle (#288)

## Description

This pull request addresses issue #288 in the BlazorGoogleMaps repository. The issue outlined a problem with the method names `SetDraggble` and `GetDraggble` in the `Polygon` and `Rectangle` classes, where they were incorrectly named and calling the wrong Google Maps methods.

## Changes Made

- Renamed `SetDraggble` to `SetDraggable` and `GetDraggble` to `GetDraggable`.
- Updated the internal calls to the Google Maps API to use the correct method names, ensuring that the draggable functionality works as intended.

## Impact

- These changes correct the typos in method names, aligning them with the correct Google Maps API methods.
- By fixing these method names, we ensure that the draggable functionality for shapes in the library works correctly, improving the overall reliability and usability of the library.

Please review the changes and let me know if there are any further modifications required. Looking forward to the feedback.

Thank you!