### PR TITLE
Fix bug #293 Incorrect serialization of Enums

### DIFF
--- a/GoogleMapsComponents/Helper.cs
+++ b/GoogleMapsComponents/Helper.cs
@@ -19,13 +19,12 @@ internal static class Helper
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters =
+        {
+            new OneOfConverterFactory(),
+            new JsonStringEnumConverterEx()
+        }
     };
-
-    static Helper()
-    {
-        Options.Converters.Add(new OneOfConverterFactory());
-        Options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
-    }
 
     internal static Task MyInvokeAsync(
         this IJSRuntime jsRuntime,

--- a/GoogleMapsComponents/Maps/AdvancedMarkerViewOptions.cs
+++ b/GoogleMapsComponents/Maps/AdvancedMarkerViewOptions.cs
@@ -15,7 +15,7 @@ namespace GoogleMapsComponents.Maps
         /// Note: AdvancedMarkerElement to AdvancedMarkerElement collision works on both raster and vector maps, however, AdvancedMarkerElement to base map's label collision only works on vector maps.
         /// </summary>
 
-        [JsonConverter(typeof(GoogleMapsComponents.Serialization.JsonStringEnumConverterEx<CollisionBehavior>))]
+        [JsonConverter(typeof(GoogleMapsComponents.Serialization.JsonStringEnumConverterEx))]
         public CollisionBehavior? CollisionBehavior { get; set; }
 
         /// <summary>

--- a/GoogleMapsComponents/Maps/Animation.cs
+++ b/GoogleMapsComponents/Maps/Animation.cs
@@ -7,7 +7,7 @@ namespace GoogleMapsComponents.Maps;
 /// Animations that can be played on a marker. 
 /// Use the setAnimation method on Marker or the animation option to play an animation.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(Serialization.JsonStringEnumConverterEx))]
 public enum Animation
 {
     /// <summary>

--- a/GoogleMapsComponents/Maps/CircleOptions.cs
+++ b/GoogleMapsComponents/Maps/CircleOptions.cs
@@ -49,7 +49,6 @@ public class CircleOptions : ListableEntityOptionsBase
     /// The stroke position. Defaults to CENTER. 
     /// This property is not supported on Internet Explorer 8 and earlier.
     /// </summary>
-    [JsonConverter(typeof(EnumMemberConverter<StrokePosition>))]
     public StrokePosition? StrokePosition { get; set; }
 
     /// <summary>

--- a/GoogleMapsComponents/Maps/CollisionBehavior.cs
+++ b/GoogleMapsComponents/Maps/CollisionBehavior.cs
@@ -2,9 +2,11 @@
 // ReSharper disable InconsistentNaming
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace GoogleMapsComponents.Maps;
 
+[JsonConverter(typeof(Serialization.JsonStringEnumConverterEx))]
 public enum CollisionBehavior
 {
     [EnumMember(Value = "google.maps.CollisionBehavior.REQUIRED")]

--- a/GoogleMapsComponents/Maps/ControlPosition.cs
+++ b/GoogleMapsComponents/Maps/ControlPosition.cs
@@ -8,7 +8,7 @@ namespace GoogleMapsComponents.Maps;
 /// Controls are positioned relative to other controls in the same layout position. 
 /// Controls that are added first are positioned closer to the edge of the map. 
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(GoogleMapsComponents.Serialization.JsonStringEnumConverterEx))]
 public enum ControlPosition
 {
     /// <summary>

--- a/GoogleMapsComponents/Maps/DirectionsRequest.cs
+++ b/GoogleMapsComponents/Maps/DirectionsRequest.cs
@@ -74,7 +74,6 @@ public class DirectionsRequest
     /// Type of routing requested. 
     /// Required.
     /// </summary>
-    [JsonConverter(typeof(EnumMemberConverter<TravelMode>))]
     public TravelMode TravelMode { get; set; }
 
     /// <summary>

--- a/GoogleMapsComponents/Maps/DirectionsStatus.cs
+++ b/GoogleMapsComponents/Maps/DirectionsStatus.cs
@@ -7,7 +7,7 @@ namespace GoogleMapsComponents.Maps;
 /// The status returned by the DirectionsService on the completion of a call to route(). 
 /// Specify these by value, or by using the constant's name. For example, 'OK' or google.maps.DirectionsStatus.OK.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(Serialization.JsonStringEnumConverterEx))]
 public enum DirectionsStatus
 {
     /// <summary>

--- a/GoogleMapsComponents/Maps/Drawing/OverlayType.cs
+++ b/GoogleMapsComponents/Maps/Drawing/OverlayType.cs
@@ -6,7 +6,7 @@ namespace GoogleMapsComponents.Maps.Drawing;
 /// <summary>
 /// The types of overlay that may be created by the DrawingManager. 
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(Serialization.JsonStringEnumConverterEx))]
 public enum OverlayType
 {
     /// <summary>

--- a/GoogleMapsComponents/Maps/GeocoderGeometry.cs
+++ b/GoogleMapsComponents/Maps/GeocoderGeometry.cs
@@ -16,7 +16,6 @@ public class GeocoderGeometry
     /// The type of location returned in <see cref="Location"></see>
     /// </summary>
     [JsonPropertyName("location_type")]
-    [JsonConverter(typeof(EnumMemberConverter<GeocoderLocationType>))]
     public GeocoderLocationType LocationType { get; set; }
 
     /// <summary>

--- a/GoogleMapsComponents/Maps/GeocoderLocationType.cs
+++ b/GoogleMapsComponents/Maps/GeocoderLocationType.cs
@@ -7,7 +7,7 @@ namespace GoogleMapsComponents.Maps;
 /// The status returned by the Geocoder on the completion of a call to geocode(). Specify these by value, or by using the constant's name.
 /// For example, 'OK' or google.maps.GeocoderStatus.OK.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(Serialization.JsonStringEnumConverterEx))]
 public enum GeocoderLocationType
 {
     /// <summary>

--- a/GoogleMapsComponents/Maps/GeocoderResponse.cs
+++ b/GoogleMapsComponents/Maps/GeocoderResponse.cs
@@ -12,6 +12,5 @@ public class GeocoderResponse
     /// </summary>
     public GeocoderResult[] Results { get; set; } = new GeocoderResult[] { };
 
-    [JsonConverter(typeof(EnumMemberConverter<GeocoderStatus>))]
     public GeocoderStatus Status { get; set; }
 }

--- a/GoogleMapsComponents/Maps/GeocoderStatus.cs
+++ b/GoogleMapsComponents/Maps/GeocoderStatus.cs
@@ -7,7 +7,7 @@ namespace GoogleMapsComponents.Maps;
 /// The status returned by the Geocoder on the completion of a call to geocode(). Specify these by value, or by using the constant's name.
 /// For example, 'OK' or google.maps.GeocoderStatus.OK.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(Serialization.JsonStringEnumConverterEx))]
 public enum GeocoderStatus
 {
     /// <summary>

--- a/GoogleMapsComponents/Maps/MapOptions.cs
+++ b/GoogleMapsComponents/Maps/MapOptions.cs
@@ -102,7 +102,6 @@ public class MapOptions
     /// The initial Map mapTypeId. Defaults to ROADMAP.
     /// </summary>
     //[JsonConverter(typeof(StringEnumConverter))]
-    [JsonConverter(typeof(EnumMemberConverter<MapTypeId>))]
     public MapTypeId MapTypeId { get; set; }
 
     /// <summary>

--- a/GoogleMapsComponents/Maps/MapTypeId.cs
+++ b/GoogleMapsComponents/Maps/MapTypeId.cs
@@ -1,10 +1,12 @@
 ﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace GoogleMapsComponents.Maps;
 
 /// <summary>
 /// Identifiers for common MapTypes
 /// </summary>
+[JsonConverter(typeof(Serialization.JsonStringEnumConverterEx))]
 public enum MapTypeId
 {
     /// <summary>

--- a/GoogleMapsComponents/Maps/MarkerOptions.cs
+++ b/GoogleMapsComponents/Maps/MarkerOptions.cs
@@ -59,7 +59,7 @@ public class MarkerOptions : ListableEntityOptionsBase
     /// <summary>
     /// 2021-07 supported only in beta google maps version
     /// </summary>
-    [JsonConverter(typeof(GoogleMapsComponents.Serialization.JsonStringEnumConverterEx<CollisionBehavior>))]
+    [JsonConverter(typeof(GoogleMapsComponents.Serialization.JsonStringEnumConverterEx))]
     public CollisionBehavior? CollisionBehavior { get; set; }
 
     /// <summary>

--- a/GoogleMapsComponents/Maps/Places/AutocompleteResponse.cs
+++ b/GoogleMapsComponents/Maps/Places/AutocompleteResponse.cs
@@ -14,6 +14,5 @@ public class AutocompleteResponse
     /// </summary>
     public AutocompletePrediction[] Predictions { get; set; } = new AutocompletePrediction[] { };
 
-    [JsonConverter(typeof(EnumMemberConverter<PlaceServiceStatus>))]
     public PlaceServiceStatus Status { get; set; }
 }

--- a/GoogleMapsComponents/Maps/Places/PlaceResponse.cs
+++ b/GoogleMapsComponents/Maps/Places/PlaceResponse.cs
@@ -6,6 +6,5 @@ public class PlaceResponse
 {
     public PlaceResult[] Results { get; set; } = new PlaceResult[] { };
 
-    [JsonConverter(typeof(EnumMemberConverter<PlaceServiceStatus>))]
     public PlaceServiceStatus Status { get; set; }
 }

--- a/GoogleMapsComponents/Maps/Places/PlaceServiceStatus.cs
+++ b/GoogleMapsComponents/Maps/Places/PlaceServiceStatus.cs
@@ -8,7 +8,7 @@ namespace GoogleMapsComponents.Maps.Places;
 /// For example, 'OK' or google.maps.places.PlacesServiceStatus.OK.
 /// Requires the &libraries=places URL parameter.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(Serialization.JsonStringEnumConverterEx))]
 public enum PlaceServiceStatus
 {
     /// <summary>

--- a/GoogleMapsComponents/Maps/Places/QueryAutocompleteResponse.cs
+++ b/GoogleMapsComponents/Maps/Places/QueryAutocompleteResponse.cs
@@ -14,6 +14,5 @@ public class QueryAutocompleteResponse
     /// </summary>
     public QueryAutocompletePrediction[] Predictions { get; set; } = new QueryAutocompletePrediction[] { };
 
-    [JsonConverter(typeof(EnumMemberConverter<PlaceServiceStatus>))]
     public PlaceServiceStatus Status { get; set; }
 }

--- a/GoogleMapsComponents/Maps/PolygonOptions.cs
+++ b/GoogleMapsComponents/Maps/PolygonOptions.cs
@@ -56,7 +56,6 @@ public class PolygonOptions : ListableEntityOptionsBase
     /// <summary>
     /// The stroke position. Defaults to CENTER. This property is not supported on Internet Explorer 8 and earlier.
     /// </summary>
-    [JsonConverter(typeof(EnumMemberConverter<StrokePosition>))]
     public StrokePosition StrokePosition { get; set; }
 
     /// <summary>

--- a/GoogleMapsComponents/Maps/RectangleOptions.cs
+++ b/GoogleMapsComponents/Maps/RectangleOptions.cs
@@ -60,7 +60,6 @@ public class RectangleOptions
     /// Defaults to CENTER. 
     /// This property is not supported on Internet Explorer 8 and earlier.
     /// </summary>
-    [JsonConverter(typeof(EnumMemberConverter<StrokePosition>))]
     public StrokePosition? StrokePosition { get; set; }
 
     /// <summary>

--- a/GoogleMapsComponents/Maps/StrokePosition.cs
+++ b/GoogleMapsComponents/Maps/StrokePosition.cs
@@ -1,7 +1,9 @@
 ﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace GoogleMapsComponents.Maps;
 
+[JsonConverter(typeof(Serialization.JsonStringEnumConverterEx))]
 public enum StrokePosition
 {
     [EnumMember(Value = "0")]

--- a/GoogleMapsComponents/Maps/SymbolPath.cs
+++ b/GoogleMapsComponents/Maps/SymbolPath.cs
@@ -1,10 +1,12 @@
 ﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace GoogleMapsComponents.Maps;
 
 /// <summary>
 /// Built-in symbol paths.
 /// </summary>
+[JsonConverter(typeof(Serialization.JsonStringEnumConverterEx))]
 public enum SymbolPath
 {
     /// <summary>

--- a/GoogleMapsComponents/Maps/TrafficModel.cs
+++ b/GoogleMapsComponents/Maps/TrafficModel.cs
@@ -6,7 +6,7 @@ namespace GoogleMapsComponents.Maps;
 /// The assumptions to use when predicting duration in traffic. 
 /// Specified as part of a DirectionsRequest or DistanceMatrixRequest. 
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(Serialization.JsonStringEnumConverterEx))]
 public enum TrafficModel
 {
     /// <summary>

--- a/GoogleMapsComponents/Maps/TravelMode.cs
+++ b/GoogleMapsComponents/Maps/TravelMode.cs
@@ -6,7 +6,7 @@ namespace GoogleMapsComponents.Maps;
 /// <summary>
 /// The valid travel modes that can be specified in a DirectionsRequest as well as the travel modes returned in a DirectionsStep. 
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(Serialization.JsonStringEnumConverterEx))]
 public enum TravelMode
 {
     /// <summary>

--- a/GoogleMapsComponents/Serialization/JsonStringEnumConverterEx.cs
+++ b/GoogleMapsComponents/Serialization/JsonStringEnumConverterEx.cs
@@ -1,71 +1,63 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace GoogleMapsComponents.Serialization;
-
-/// <summary>
-/// TODO apply to all enum with EnumMember attribute
-/// </summary>
-/// <typeparam name="TEnum"></typeparam>
-public class JsonStringEnumConverterEx<TEnum> : JsonConverter<TEnum> where TEnum : struct, Enum
+public class JsonStringEnumConverterEx : JsonConverterFactory
 {
+    private readonly ConcurrentDictionary<Type, EnumConverter> _converters = new ConcurrentDictionary<Type, EnumConverter>();
 
-    private readonly Dictionary<TEnum, string> _enumToString = new Dictionary<TEnum, string>();
-    private readonly Dictionary<string, TEnum> _stringToEnum = new Dictionary<string, TEnum>();
-
-    public JsonStringEnumConverterEx()
+    public override bool CanConvert(Type typeToConvert)
     {
-        var type = typeof(TEnum);
-        var values = Enum.GetValues(typeof(TEnum));
+        return typeToConvert.IsEnum;
+    }
 
-        foreach (var value in values)
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        return _converters.GetOrAdd(typeToConvert, (type) => new EnumConverter(type));
+    }
+
+    private class EnumConverter : JsonConverter<Enum>
+    {
+        private readonly Dictionary<string, Enum> _stringToEnum;
+        private readonly Dictionary<Enum, string> _enumToString;
+
+        public EnumConverter(Type enumType)
         {
-            var enumMember = type.GetMember(value.ToString())[0];
-            var attr = enumMember
-                .GetCustomAttributes(typeof(EnumMemberAttribute), false)
-                .Cast<EnumMemberAttribute>()
-                .FirstOrDefault();
+            _stringToEnum = new Dictionary<string, Enum>();
+            _enumToString = new Dictionary<Enum, string>();
 
-            _stringToEnum.Add(value.ToString(), (TEnum)value);
+            var enumValues = Enum.GetValues(enumType);
+            foreach (Enum value in enumValues)
+            {
+                var name = value.ToString();
+                var enumMemberAttr = enumType.GetField(name)
+                    .GetCustomAttribute<EnumMemberAttribute>();
 
-            if (attr?.Value != null)
-            {
-                _enumToString.Add((TEnum)value, attr.Value);
-                _stringToEnum.Add(attr.Value, (TEnum)value);
-            }
-            else
-            {
-                _enumToString.Add((TEnum)value, value.ToString());
+                var stringKey = enumMemberAttr?.Value ?? name;
+                _stringToEnum[stringKey] = value;
+                _enumToString[value] = stringKey;
             }
         }
-    }
 
-    public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-    {
-        var stringValue = reader.GetString();
-
-        if (_stringToEnum.TryGetValue(stringValue, out var enumValue))
+        public override Enum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return enumValue;
+            var stringValue = reader.GetString();
+            if (_stringToEnum.TryGetValue(stringValue, out var enumValue))
+            {
+                return enumValue;
+            }
+
+            throw new JsonException($"Unable to convert \"{stringValue}\" to enum {typeToConvert}.");
         }
 
-        return default;
-    }
-
-    public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
-    {
-        writer.WriteStringValue(_enumToString[value]);
-    }
-
-    public static string ToLowerFirstChar(string str)
-    {
-        if (String.IsNullOrEmpty(str) || Char.IsLower(str, 0))
-            return str;
-
-        return Char.ToLowerInvariant(str[0]) + str.Substring(1);
+        public override void Write(Utf8JsonWriter writer, Enum value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(_enumToString[value]);
+        }
     }
 }


### PR DESCRIPTION

# Fix Incorrect Serialization of Enums in BlazorGoogleMaps

## Description
This pull request addresses a critical issue in the BlazorGoogleMaps repository concerning the incorrect serialization of enums. The issue not only affected the positioning of map controls but might have also impacted other parts of the library due to improper use of the `EnumMember` attribute in JSON serialization.

## Changes Made
- Added the `JsonConvert` attribute to all enums using the `JsonStringEnumConverterEx` converter.
- Ensured that all enums use `JsonStringEnumConverterEx` instead of `JsonStringEnumConverter`.
- Updated the `JsonStringEnumConverterEx` class to be a factory for converters, utilizing a concurrent dictionary for caching converters. This allows only one converter to be added to the `JsonSerializerOptions`, improving performance and consistency across the library.

## Impact
- These changes ensure that enums are serialized correctly, respecting the `EnumMember` attribute.
- The update to the `JsonStringEnumConverterEx` class enhances the efficiency and reliability of the serialization process across the library.
- By fixing these serialization issues, the overall functionality and usability of the entire BlazorGoogleMaps library should be improved.

Please review the changes and let me know if there are any further modifications required. Looking forward to the feedback.

Thank you!