### PR TITLE
Add Custom Control Removal Functionality

### DIFF
--- a/GoogleMapsComponents/Maps/Map.cs
+++ b/GoogleMapsComponents/Maps/Map.cs
@@ -45,6 +45,16 @@ public class Map : EventEntityBase, IJsObjectRef, IDisposable, IAsyncDisposable
         await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("blazorGoogleMaps.objectManager.addControls", this.Guid.ToString(), position, reference);
     }
 
+    public async Task RemoveControl(ControlPosition position, ElementReference reference)
+    {
+        await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("blazorGoogleMaps.objectManager.removeControl", this.Guid.ToString(), position, reference);
+    }
+
+    public async Task RemoveAllControls(ControlPosition position)
+    {
+        await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("blazorGoogleMaps.objectManager.clearControls", this.Guid.ToString(), position);
+    }
+
     public async Task AddImageLayer(ImageMapType reference)
     {
         await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("blazorGoogleMaps.objectManager.addImageLayer", this.Guid.ToString(), reference.Guid.ToString());

--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -392,10 +392,30 @@
             addControls(args) {
                 let map = mapObjects[args[0]];
                 let elem = args[2];
+                let clone = elem.cloneNode(true);
                 //I know i am lazy. Two quotes appear after serialization
                 let position = getGooglePositionFromString(args[1].replace("\"", "").replace("\"", ""));
 
-                map.controls[position].push(elem);
+                map.controls[position].push(clone);
+            },
+            removeControl(args) {
+                let map = mapObjects[args[0]];
+                let elem = args[2];
+                let position = getGooglePositionFromString(args[1].replace("\"", "").replace("\"", ""));
+
+                var arr = map.controls[position].getArray();
+                for (var i = 0, len = arr.length; i < len; i++) {
+                    if (arr[i].id === elem.id) {
+                        map.controls[position].removeAt(i);
+                        return;
+                    }
+                }
+            },
+            clearControls(args) {
+                let map = mapObjects[args[0]];
+                let position = getGooglePositionFromString(args[1].replace("\"", "").replace("\"", ""));
+
+                map.controls[position].clear();
             },
             addImageLayer(args) {
                 let map = mapObjects[args[0]];

--- a/ServerSideDemo/Pages/MapLegendPage.razor
+++ b/ServerSideDemo/Pages/MapLegendPage.razor
@@ -4,6 +4,9 @@
 <h1>Google Map Legend</h1>
 
 <GoogleMap @ref="@map1" Id="map1" Options="@mapOptions" OnAfterInit="@AfterMapInit"></GoogleMap>
+<button @onclick="AddLegend">Add Legend</button>
+<button @onclick="RemoveLegend">Remove Legend</button>
+<button @onclick="RemoveAllControls">Remove All Controls</button>
 
 <div id="legend" @ref="@legendReference" style="visibility: hidden"><h3>Legend</h3></div>
 

--- a/ServerSideDemo/Pages/MapLegendPage.razor.cs
+++ b/ServerSideDemo/Pages/MapLegendPage.razor.cs
@@ -40,6 +40,21 @@ public partial class MapLegendPage
 
     private async Task AfterMapInit()
     {
+        
+    }
+
+    private async Task RemoveLegend()
+    {
+        await map1.InteropObject.RemoveControl(ControlPosition.TopLeft, legendReference);
+    }
+
+    private async Task RemoveAllControls()
+    {
+        await map1.InteropObject.RemoveAllControls(ControlPosition.TopLeft);
+    }
+
+    private async Task AddLegend()
+    {
         await map1.InteropObject.AddControl(ControlPosition.TopLeft, legendReference);
     }
 }


### PR DESCRIPTION
## Description
This pull request introduces the implementation of a new feature for the BlazorGoogleMaps library, enabling the removal of custom controls from the map. This enhancement aligns with the feature request submitted earlier. The changes include the addition of `RemoveControl` and `RemoveAllControls` methods in the `Map.cs` class for dynamic control management.

## Implemented Changes
1. **Map.cs**:
    - Added `RemoveControl(ControlPosition controlPosition, ElementReference elementReference)` for removing a specific control based on its position and element reference.
    - Added `RemoveAllControls(ControlPosition controlPosition)` for removing all controls at a given position.

2. **objectManager.js**:
    - Updated to support the new control removal functionality.
    - Updated AddControl to clone the elementReference. Without this the original element is removed and can not be added again.

3. **Razor Components**:
    - Modified to demonstrate the new methods for adding and removing controls on the map.


## Impact
- The addition of these methods allows for dynamic control of the map elements.
- It provides developers with greater flexibility in customizing the map's UI and responding to user interactions.

I'm looking forward to the review and hopeful integration of this new functionality into the BlazorGoogleMaps library.

Thank you for considering this pull request!
