### PR TITLE
Custom controls not being added in specified position

### DIFF
--- a/GoogleMapsComponents/EnumExtensions.cs
+++ b/GoogleMapsComponents/EnumExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace GoogleMapsComponents
+{
+    internal static class EnumExtensions
+    {
+        public static string? GetMemberAttr(this Enum enumItem)
+        {
+            var memberInfo = enumItem.GetType().GetMember(enumItem.ToString());
+            if (memberInfo.Length == 0) { return null; }
+
+            foreach (var attr in memberInfo[0].GetCustomAttributes(false))
+            {
+                if (attr is System.Runtime.Serialization.EnumMemberAttribute val)
+                {
+                    return val.Value;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/GoogleMapsComponents/Maps/ControlPosition.cs
+++ b/GoogleMapsComponents/Maps/ControlPosition.cs
@@ -4,9 +4,9 @@ using System.Text.Json.Serialization;
 namespace GoogleMapsComponents.Maps;
 
 /// <summary>
-/// Identifiers used to specify the placement of controls on the map. 
-/// Controls are positioned relative to other controls in the same layout position. 
-/// Controls that are added first are positioned closer to the edge of the map. 
+/// Identifiers used to specify the placement of controls on the map.
+/// Controls are positioned relative to other controls in the same layout position.
+/// Controls that are added first are positioned closer to the edge of the map.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ControlPosition
@@ -18,14 +18,14 @@ public enum ControlPosition
     BottomCenter,
 
     /// <summary>
-    /// Elements are positioned in the bottom left and flow towards the middle. 
+    /// Elements are positioned in the bottom left and flow towards the middle.
     /// Elements are positioned to the right of the Google logo.
     /// </summary>
     [EnumMember(Value = "BOTTOM_LEFT")]
     BottomLeft,
 
     /// <summary>
-    /// Elements are positioned in the bottom right and flow towards the middle. 
+    /// Elements are positioned in the bottom right and flow towards the middle.
     /// Elements are positioned to the left of the copyrights.
     /// </summary>
     [EnumMember(Value = "BOTTOM_RIGHT")]

--- a/GoogleMapsComponents/Maps/Map.cs
+++ b/GoogleMapsComponents/Maps/Map.cs
@@ -40,17 +40,17 @@ public class Map : EventEntityBase, IJsObjectRef, IAsyncDisposable
 
     public async Task AddControl(ControlPosition position, ElementReference reference)
     {
-        await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("blazorGoogleMaps.objectManager.addControls", this.Guid.ToString(), position, reference);
+        await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("blazorGoogleMaps.objectManager.addControls", this.Guid.ToString(), position.GetMemberAttr(), reference);
     }
 
     public async Task RemoveControl(ControlPosition position, ElementReference reference)
     {
-        await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("blazorGoogleMaps.objectManager.removeControl", this.Guid.ToString(), position, reference);
+        await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("blazorGoogleMaps.objectManager.removeControl", this.Guid.ToString(), position.GetMemberAttr(), reference);
     }
 
     public async Task RemoveControls(ControlPosition position)
     {
-        await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("blazorGoogleMaps.objectManager.removeControls", this.Guid.ToString(), position);
+        await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("blazorGoogleMaps.objectManager.removeControls", this.Guid.ToString(), position.GetMemberAttr());
     }
 
     public async Task AddImageLayer(ImageMapType reference)
@@ -65,8 +65,6 @@ public class Map : EventEntityBase, IJsObjectRef, IAsyncDisposable
     {
         await _jsObjectRef.JSRuntime.MyInvokeAsync<object>("blazorGoogleMaps.objectManager.removeAllImageLayers", this.Guid.ToString());
     }
-
-
 
     /// <summary>
     /// Sets the viewport to contain the given bounds.

--- a/ServerSideDemo/Pages/MapLegendPage.razor
+++ b/ServerSideDemo/Pages/MapLegendPage.razor
@@ -1,9 +1,16 @@
 ﻿@page "/map-legend"
 @using GoogleMapsComponents
+@using GoogleMapsComponents.Maps
 
 <h1>Google Map Legend</h1>
 
 <GoogleMap @ref="@map1" Id="map1" Options="@mapOptions" OnAfterInit="@AfterMapInit"></GoogleMap>
+<select @bind="@controlPosition">
+    @foreach(var pos in Enum.GetValues(typeof(ControlPosition)))
+    {
+        <option value="@pos">@pos.ToString()</option>
+    }
+</select> 
 <button @onclick="AddLegend">Add Legend</button>
 <button @onclick="RemoveLegend">Remove Legend</button>
 <button @onclick="RemoveAllControls">Remove All Controls</button>

--- a/ServerSideDemo/Pages/MapLegendPage.razor.cs
+++ b/ServerSideDemo/Pages/MapLegendPage.razor.cs
@@ -12,6 +12,8 @@ public partial class MapLegendPage
 
     private MapOptions mapOptions;
 
+    private ControlPosition controlPosition = ControlPosition.TopLeft;
+
     [Inject] private IJSRuntime jsRuntime { get; set; }
 
     protected ElementReference legendReference { get; set; }
@@ -40,21 +42,20 @@ public partial class MapLegendPage
 
     private async Task AfterMapInit()
     {
-
     }
 
     private async Task RemoveLegend()
     {
-        await map1.InteropObject.RemoveControl(ControlPosition.TopLeft, legendReference);
+        await map1.InteropObject.RemoveControl(controlPosition, legendReference);
     }
 
     private async Task RemoveAllControls()
     {
-        await map1.InteropObject.RemoveControls(ControlPosition.TopLeft);
+        await map1.InteropObject.RemoveControls(controlPosition);
     }
 
     private async Task AddLegend()
     {
-        await map1.InteropObject.AddControl(ControlPosition.TopLeft, legendReference);
+        await map1.InteropObject.AddControl(controlPosition, legendReference);
     }
 }


### PR DESCRIPTION
Fixed issue where `AddControl`, `RemoveControl` and `RemoveControls` methods of `Map` object did not honour the specified ControlPosition.

Updated `MapLegendPage` in `ServerSideDemo` to allow selecting the position where the legend will be added.