### PR TITLE
Fix bug: OnClick events from elements in custom controls not working after v3.3.1

### DIFF
--- a/GoogleMapsComponents/Maps/Map.cs
+++ b/GoogleMapsComponents/Maps/Map.cs
@@ -246,9 +246,9 @@ public class Map : EventEntityBase, IJsObjectRef, IAsyncDisposable
 
     protected override async ValueTask DisposeAsyncCore()
     {
+        await _jsObjectRef.JSRuntime.InvokeAsync<object>("blazorGoogleMaps.objectManager.disposeMapElements", Guid.ToString());
         await base.DisposeAsyncCore();
         JsObjectRefInstances.Remove(_jsObjectRef.Guid.ToString());
-        await _jsObjectRef.JSRuntime.InvokeAsync<object>("blazorGoogleMaps.objectManager.disposeMapElements", Guid.ToString());
     }
 
     protected override void Dispose(bool disposing)

--- a/ServerSideDemo/Pages/MapLegendPage.razor
+++ b/ServerSideDemo/Pages/MapLegendPage.razor
@@ -13,9 +13,13 @@
 </select>
 <button @onclick="AddLegend">Add Legend</button>
 <button @onclick="RemoveLegend">Remove Legend</button>
+<button @onclick="AddLegend2">Add Legend 2</button>
+<button @onclick="RemoveLegend2">Remove Legend 2</button>
 <button @onclick="RemoveAllControls">Remove All Controls</button>
 
-<div id="legend" @ref="@LegendReference" style="visibility: hidden"><h3>Legend</h3></div>
+<div id="legend" @ref="@LegendReference" style="display: none"><h3>Legend  </h3><button @onclick="() => HandleClick()">Alert from blazor</button></div>
+<div id="legend2" @ref="@LegendReference2" style="display: none"><h3>Legend 2 </h3><button @onclick="() => HandleClick()">Alert from blazor</button></div>
+
 
 <style>
     html, body {
@@ -29,7 +33,7 @@
         height: 400px;
         width: 100%;
     }
-
+    #legend2, 
     #legend {
         font-family: Arial, sans-serif;
         background: #fff;

--- a/ServerSideDemo/Pages/MapLegendPage.razor.cs
+++ b/ServerSideDemo/Pages/MapLegendPage.razor.cs
@@ -15,6 +15,7 @@ public partial class MapLegendPage
     [Inject] private IJSRuntime JsRuntime { get; set; }
 
     protected ElementReference LegendReference { get; set; }
+    protected ElementReference LegendReference2 { get; set; }
 
     protected override void OnInitialized()
     {
@@ -43,9 +44,24 @@ public partial class MapLegendPage
         return Task.CompletedTask;
     }
 
+    private async Task AddLegend()
+    {
+        await _map1.InteropObject.AddControl(_controlPosition, LegendReference);
+    }
+
+    private async Task AddLegend2()
+    {
+        await _map1.InteropObject.AddControl(_controlPosition, LegendReference2);
+    }
+
     private async Task RemoveLegend()
     {
         await _map1.InteropObject.RemoveControl(_controlPosition, LegendReference);
+    }
+
+    private async Task RemoveLegend2()
+    {
+        await _map1.InteropObject.RemoveControl(_controlPosition, LegendReference2);
     }
 
     private async Task RemoveAllControls()
@@ -53,8 +69,8 @@ public partial class MapLegendPage
         await _map1.InteropObject.RemoveControls(_controlPosition);
     }
 
-    private async Task AddLegend()
+    private async Task HandleClick()
     {
-        await _map1.InteropObject.AddControl(_controlPosition, LegendReference);
+        await JsRuntime.InvokeVoidAsync("alert", "Hello from Blazor");
     }
 }

--- a/ServerSideDemo/Pages/MapsLegendPage.razor
+++ b/ServerSideDemo/Pages/MapsLegendPage.razor
@@ -1,0 +1,149 @@
+﻿@page "/maps-legend"
+@using GoogleMapsComponents.Maps
+@inject IJSRuntime JsRuntime
+@implements IAsyncDisposable
+
+<h1>Maps legend</h1>
+
+<button @onclick="AddMap1">Add Map1</button>
+<button @onclick="RemoveMap1">Remove Map1</button>
+<button @onclick="AddMap2">Add Map2</button>
+<button @onclick="RemoveMap2">Remove Map2</button>
+
+<button @onclick="AddLegendMap1">Add Legend (Map1)</button>
+<button @onclick="RemoveLegendMap1">Remove Legend (Map1)</button>
+<button @onclick="AddLegendMap2">Add Legend (Map2)</button>
+<button @onclick="RemoveLegendMap2">Remove Legend (Map2)</button>
+<button @onclick="RemoveAllControls">Remove All Controls (Both maps)</button>
+
+<div @ref="@_map1ElementRef" id="map1" style="height: 450px; display: @(_map1 is null ? "none" : "block")"></div>
+<div id="legendMap1" @ref="@legendReferenceMap1" style="display: none"><h3>Legend  </h3><button @onclick="() => HandleClick()">Alert from blazor</button></div>
+<div id="legendMap2" @ref="@legendReferenceMap2" style="display: none"><h3>Legend  </h3><button @onclick="() => HandleClick()">Alert from blazor</button></div>
+
+<div @ref="@_map2ElementRef" id="map2" style="height: 450px; display: @(_map2 is null ? "none" : "block")"></div>
+
+
+@code {
+    private Map _map1, _map2;
+
+    private ElementReference _map1ElementRef, _map2ElementRef;
+
+    protected ElementReference legendReferenceMap1 { get; set; }
+    protected ElementReference legendReferenceMap2 { get; set; }
+
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if(firstRender)
+        {
+            await AddMap1();
+            await AddMap2();
+            StateHasChanged();
+        }
+    }
+
+    private async Task AfterMapInit()
+    {
+
+    }
+
+    private async Task<Map> CreateMap(ElementReference elementReference)
+    {
+
+        var mapOptions = new MapOptions()
+            {
+                Zoom = 13,
+                Center = new LatLngLiteral()
+                {
+                    Lat = 13.505892,
+                    Lng = 100.8162
+                },
+                MapTypeId = MapTypeId.Roadmap
+            };
+        return await Map.CreateAsync(JsRuntime, elementReference, mapOptions);
+    }
+
+    private async Task AddMap1()
+    {
+        if (_map1 == null)
+        {
+            _map1 = await CreateMap(_map1ElementRef);
+        }
+    }
+
+    private async Task AddMap2()
+    {
+        if (_map2 == null)
+        {
+            _map2 = await CreateMap(_map2ElementRef);
+        }
+    }
+
+    private async Task RemoveMap1()
+    {
+        if (_map1 != null)
+        {
+            await _map1.DisposeAsync();
+            _map1 = null;
+        }
+    }
+
+    private async Task RemoveMap2()
+    {
+        if (_map2 != null)
+        {
+            await _map2.DisposeAsync();
+            _map2 = null;
+        }
+    }
+
+    private async Task AddLegendMap1()
+    {
+        await _map1.AddControl(ControlPosition.BottomCenter, legendReferenceMap1);
+    }
+
+    private async Task RemoveLegendMap1()
+    {
+        await _map1.RemoveControl(ControlPosition.BottomCenter, legendReferenceMap1);
+    }
+
+    private async Task AddLegendMap2()
+    {
+        await _map2.AddControl(ControlPosition.BottomCenter, legendReferenceMap2);
+    }
+
+    private async Task RemoveLegendMap2()
+    {
+        await _map2.RemoveControl(ControlPosition.BottomCenter, legendReferenceMap2);
+    }
+
+    private async Task RemoveAllControls()
+    {
+        if(_map1 is not null) 
+        {
+            await _map1.RemoveControls(ControlPosition.BottomCenter);
+        }
+        if(_map2 is not null) 
+        {
+            await _map2.RemoveControls(ControlPosition.BottomCenter);
+        }   
+    }
+
+    private async Task HandleClick()
+    {
+        await JsRuntime.InvokeVoidAsync("alert", "Hello from Blazor");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_map1 != null)
+        {
+            await _map1.DisposeAsync();
+        }
+
+        if (_map2 != null)
+        {
+            await _map2.DisposeAsync();
+        }
+    }
+}

--- a/ServerSideDemo/Shared/NavMenu.razor
+++ b/ServerSideDemo/Shared/NavMenu.razor
@@ -83,6 +83,11 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="maps-legend">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Maps Legend
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="map-marker-list">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Map Marker List
             </NavLink>


### PR DESCRIPTION
## Description
This pull request fixes a bug introduced in v3.3.1, issue #298,  where OnClick events from elements in custom controls stopped working.
It also disposes used resources.

## Implemented Changes

objectManager.js:

1. Removal of elem.clone() in addControls:

- Issue Addressed: Previously, elem.clone() was used, which led to problems with OnClick events in Blazor. Cloning a DOM element does not copy event listeners attached to it, causing loss of interactivity.

- Resolution: Removed the cloning process. Now, the original element (elem) is directly used, preserving its event listeners and functionality.

2. Enhanced Handling of controlParents:

- Multi-map Support: Adjusted the controlParents object to handle controls from multiple maps. 

- Proper Disposal: Ensured that controlParents is disposed of correctly when a map is removed. 

3. Refactoring for Better Management:

- Addition and Removal Logic: With the removal of elem.clone(), the addition and removal logic for controls now deals directly with the original elements, ensuring that their state and events are preserved.

- Visibility and Parent Management: Controls are now shown or hidden as needed and are always returned to their original parent when removed from the map, maintaining the expected behavior.

## New and Updated Examples
### New: MapsLegendPage

Demonstrates custom controls in multi-map scenarios, highlighting independent control management across different maps.
### Updated: MapLegendPage

Showcases enhanced add/remove control features with event handling, focusing on Blazor component interactions.

Thank you for considering this pull request!