### PR TITLE
Implement bootstrapping via service

### DIFF
--- a/GoogleMapsComponents/BlazorGoogleMapsKeyService.cs
+++ b/GoogleMapsComponents/BlazorGoogleMapsKeyService.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading.Tasks;
+
+namespace GoogleMapsComponents;
+
+/// <summary>
+/// Interface for the key service that is injected into the Map Component in order to retrieve
+/// a google api key when injecting the google api JS package
+/// </summary>
+public interface IBlazorGoogleMapsKeyService
+{
+    public Task<Maps.MapApiLoadOptions> GetApiOptions();
+
+    public bool IsApiInitialized { get; set; }
+}
+
+/// <summary>
+/// Basic implmentation of <see cref="IBlazorGoogleMapsKeyService"/> to load Google API JS dynamically instead of through _Hosts.cshtml.<br/> 
+/// Replace with your own service to provide keys via dynamic lookup.
+/// </summary>
+public class BlazorGoogleMapsKeyService : IBlazorGoogleMapsKeyService
+{
+    private readonly Maps.MapApiLoadOptions initOptions;
+    public bool IsApiInitialized { get; set; } = false;
+
+    public BlazorGoogleMapsKeyService(string key)
+    {
+        initOptions = new Maps.MapApiLoadOptions(key);
+    }
+    public BlazorGoogleMapsKeyService(Maps.MapApiLoadOptions opts)
+    {
+        initOptions = opts;
+    }
+    public Task<Maps.MapApiLoadOptions> GetApiOptions()
+    {
+        // Can do async things to get the API key if needed here.
+        return Task.FromResult(initOptions);
+    }
+}

--- a/GoogleMapsComponents/DependencyInjectionExtensions.cs
+++ b/GoogleMapsComponents/DependencyInjectionExtensions.cs
@@ -5,46 +5,23 @@ namespace GoogleMapsComponents;
 
 public static class DependencyInjectionExtensions
 {
-    internal static BlazorGoogleMapsOptions MapOptions { get; set; } = new BlazorGoogleMapsOptions();
-    public static IServiceCollection AddBlazorGoogleMaps(this IServiceCollection service, Action<BlazorGoogleMapsOptions>? opts = null)
+    /// <summary>
+    /// Adds a basic service to provide a google api key for the application when using bootstrap loader method for Google API <para/>
+    /// 
+    /// If implementing your own key service, be sure to register the service as the implementation of <see cref="IBlazorGoogleMapsKeyService"/>,
+    /// so that the <see cref="GoogleMap"/> component can find it. For example instead of this function you might use:
+    /// <code>services.AddScoped&lt;<see cref="IBlazorGoogleMapsKeyService"/>, YourServiceImplmentation&gt;();</code>
+    /// </summary>
+    public static IServiceCollection AddBlazorGoogleMaps(this IServiceCollection services, string key)
     {
-        MapOptions = new BlazorGoogleMapsOptions();
-        opts?.Invoke(MapOptions);
-
-        if (MapOptions.UseBootstrapLoader)
-        {
-            if (MapOptions.KeyProvider is null)
-            {
-                throw new ArgumentNullException(nameof(MapOptions.KeyProvider), "Key is required when using bootstrap loader.");
-            }
-
-        }
-
-        return service;
+        services.AddScoped<IBlazorGoogleMapsKeyService>(serviceProvider => new BlazorGoogleMapsKeyService(key));
+        return services;
     }
-}
 
-//All options
-//https://developers.google.com/maps/documentation/javascript/load-maps-js-api#required_parameters
-public class BlazorGoogleMapsOptions
-{
-    /// <summary>
-    /// Is selected option then it uses the bootstrap loader to load the google maps script.
-    /// https://developers.google.com/maps/documentation/javascript/overview#Loading_the_Maps_API
-    /// </summary>
-    public bool UseBootstrapLoader { get; set; }
-
-    /// <summary>
-    /// Default is weekly.
-    /// https://developers.google.com/maps/documentation/javascript/versions
-    /// </summary>
-    public string Version { get; set; } = "weekly";
-
-    /// <summary>
-    /// Comma separated list of libraries to load.
-    /// https://developers.google.com/maps/documentation/javascript/libraries
-    /// </summary>
-    public string? Libraries { get; set; }
-
-    public Func<string>? KeyProvider { get; set; }
+    /// <inheritdoc cref="AddBlazorGoogleMaps(IServiceCollection, string)"/>
+    public static IServiceCollection AddBlazorGoogleMaps(this IServiceCollection services, Maps.MapApiLoadOptions opts)
+    {
+        services.AddScoped<IBlazorGoogleMapsKeyService>(serviceProvider => new BlazorGoogleMapsKeyService(opts));
+        return services;
+    }
 }

--- a/GoogleMapsComponents/GoogleMap.razor
+++ b/GoogleMapsComponents/GoogleMap.razor
@@ -64,7 +64,7 @@
 
         //Debug.WriteLine("Init finished");
 
-        await OnAfterInit.InvokeAsync(null);
+        await OnAfterInit.InvokeAsync();
     }
 
     protected override bool ShouldRender()

--- a/GoogleMapsComponents/GoogleMapsComponents.csproj
+++ b/GoogleMapsComponents/GoogleMapsComponents.csproj
@@ -15,7 +15,7 @@
 		<RazorLangVersion>3.0</RazorLangVersion>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>BlazorGoogleMaps</PackageId>
-		<Version>4.2.0</Version>
+		<Version>4.3.0</Version>
 		<Authors>Rungwiroon</Authors>
 		<Company>QueueStack Solution</Company>
 		<Product>BlazorGoogleMaps</Product>

--- a/GoogleMapsComponents/Maps/Map.cs
+++ b/GoogleMapsComponents/Maps/Map.cs
@@ -23,13 +23,13 @@ public class Map : EventEntityBase, IJsObjectRef, IAsyncDisposable
         ElementReference mapDiv,
         MapOptions? opts = null)
     {
-        if (DependencyInjectionExtensions.MapOptions.UseBootstrapLoader)
+        if (opts?.ApiLoadOptions != null)
         {
-            var mapOpts = DependencyInjectionExtensions.MapOptions;
+            MapApiLoadOptions apiOpts = opts.ApiLoadOptions;
             await jsRuntime.InvokeVoidAsync("blazorGoogleMaps.objectManager.initMap",
-                mapOpts.KeyProvider?.Invoke(),
-                mapOpts.Version,
-                mapOpts.Libraries);
+                apiOpts.Key,
+                apiOpts.Version,
+                apiOpts.Libraries);
         }
         var jsObjectRef = await JsObjectRef.CreateAsync(jsRuntime, "google.maps.Map", mapDiv, opts);
         var dataObjectRef = await jsObjectRef.GetObjectReference("data");

--- a/GoogleMapsComponents/Maps/MapApiLoadOptions.cs
+++ b/GoogleMapsComponents/Maps/MapApiLoadOptions.cs
@@ -1,0 +1,25 @@
+﻿namespace GoogleMapsComponents.Maps;
+
+/// <summary>
+/// All options
+/// https://developers.google.com/maps/documentation/javascript/load-maps-js-api#required_parameters <br/>
+/// </summary>
+public class MapApiLoadOptions(string key)
+{
+    /// <summary>
+    /// Default is weekly.
+    /// https://developers.google.com/maps/documentation/javascript/versions
+    /// </summary>
+    public string Version { get; set; } = "weekly";
+
+    /// <summary>
+    /// Comma separated list of libraries to load.
+    /// https://developers.google.com/maps/documentation/javascript/libraries
+    /// </summary>
+    public string? Libraries { get; set; } = "places,visualization,drawing,marker";
+
+    /// <summary>
+    /// Synchronous key provider function used by the default implementation
+    /// </summary>
+    public string? Key { get; set; } = key;
+}

--- a/GoogleMapsComponents/Maps/MapOptions.cs
+++ b/GoogleMapsComponents/Maps/MapOptions.cs
@@ -8,6 +8,17 @@ namespace GoogleMapsComponents.Maps;
 public class MapOptions
 {
     /// <summary>
+    /// Leave null when initializing Google Maps API normally, for example:<br/>
+    /// <list type="bullet">
+    /// <item>when relying on <see cref="IBlazorGoogleMapsKeyService"/> scoped service</item>
+    /// <item>when loading google API JS through _Host.cshtml or _HostLayout.cshtml</item>
+    /// </list>
+    /// When not null, MapComponent will load Google API using the bootstrap method.<br/>
+    /// <seealso href="https://developers.google.com/maps/documentation/javascript/overview#Loading_the_Maps_API"/> 
+    /// </summary>
+    public MapApiLoadOptions? ApiLoadOptions { get; set; }
+
+    /// <summary>
     /// Color used for the background of the Map div.<br/>
     /// This color will be visible when tiles have not yet loaded as the user pans.<br/>
     /// This option can only be set when the map is initialized.

--- a/README.md
+++ b/README.md
@@ -4,33 +4,41 @@ Blazor interop for GoogleMap library
 [![NuGet version (BlazorGoogleMaps)](https://img.shields.io/nuget/v/BlazorGoogleMaps)](https://www.nuget.org/packages/BlazorGoogleMaps/)
 
 ## Usage
-1. Add google map script HEAD tag to wwwroot/index.html in Client side or _Host.cshtml in Server Side.
-How to get key follow https://developers.google.com/maps/documentation/javascript/get-api-key
+1. Provide your Google API key to BlazorGoogleMaps with one of the following methods. (You can get a key here: https://developers.google.com/maps/documentation/javascript/get-api-key)
+
+Use the bootstrap loader with a key service (recommended):
+```
+services.AddBlazorGoogleMaps("YOUR_KEY_GOES_HERE");
+```
+OR specify google api libraries and/or version:
+```
+services.AddBlazorGoogleMaps(new GoogleMapsComponents.Map.MapApiLoadOptions("YOUR_KEY_GOES_HERE")
+    {
+        Version = "beta",
+        Libraries = "places,visualization,drawing,marker",
+    });
+```
+OR to do something more complex (e.g. looking up keys asynchronously), implement a Scoped key service and add it with something like:
+```
+services.AddScoped<IBlazorGoogleMapsKeyService, YourServiceImplementation>();
+```
+
+OR (legacy - not recommended) Add google map script HEAD tag to wwwroot/index.html in Client side or _Host.cshtml in Server Side.
 ```
 <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=YOUR_KEY_GOES_HERE&v=3"></script>
 ```
 
-To use Google recommended way by using bootstrap loader use 
-```
-services.AddBlazorGoogleMaps(opt =>
-    {
-        opt.KeyProvider = () => "YOUR_KEY_GOES_HERE";
-        opt.UseBootstrapLoader = true;
-        opt.Version = "beta";
-        opt.Libraries = "places,visualization,drawing,marker";
-    });
-```
 
-Add path to project javascript functions file in wwwroot/index.html in Client side or _Host.cshtml in Server Side.
+2. Add path to project javascript functions file in wwwroot/index.html for Blazor WASM, or in _Host.cshtml or _HostLayout.cshtml for Blazor Server.
 ```
 <script src="_content/BlazorGoogleMaps/js/objectManager.js"></script>
 ```
-If you want to use marker clustering add the following script to _Host.cshtml.
+If you want to use marker clustering add this script as well:
 ```
 <script src="https://unpkg.com/@@googlemaps/markerclusterer/dist/index.min.js"></script>
 ```
 
-2. Use component in client and server side same
+3. Using the component is the same for both Blazor WASM and Blazor Server
 ```
 @page "/map"
 @using GoogleMapsComponents
@@ -71,12 +79,11 @@ If you want to use marker clustering add the following script to _Host.cshtml.
  ClientSide demos online
  https://rungwiroon.github.io/BlazorGoogleMaps/mapEvents
 
-
-**Breaking change from 2.0.0**
-LatLngLiteral constructor's parameters order changed #173
+**Breaking change from 4.0.0**
+Migrate to .NET 8 #286.
 
 **Breaking change from 3.0.0**
 Migrate from Newtonsoft.Json to System.Text.Json.
 
-**Breaking change from 4.0.0**
-Migrate to .net 8 #286.
+**Breaking change from 2.0.0**
+LatLngLiteral constructor's parameters order changed #173

--- a/ServerSideDemo/Pages/MapLegendPage.razor.cs
+++ b/ServerSideDemo/Pages/MapLegendPage.razor.cs
@@ -45,7 +45,8 @@ public partial class MapLegendPage
     {
         if (firstRender)
         {
-            await JsRuntime.InvokeAsync<object>("initMapLegend");
+            IJSObjectReference serverSideScripts = await JsRuntime.InvokeAsync<IJSObjectReference>("import", "/js/serverSideScripts.js");
+            await serverSideScripts.InvokeVoidAsync("initMapLegend");
         }
     }
 

--- a/ServerSideDemo/Pages/Maps.razor
+++ b/ServerSideDemo/Pages/Maps.razor
@@ -23,6 +23,9 @@
 
     private ElementReference _map1ElementRef, _map2ElementRef;
 
+    [Inject]
+    public GoogleMapsComponents.IBlazorGoogleMapsKeyService KeyService { get; set; }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (_map1 == null)
@@ -35,7 +38,8 @@
                         Lat = 13.505892,
                         Lng = 100.8162
                     },
-                    MapTypeId = MapTypeId.Roadmap
+                    MapTypeId = MapTypeId.Roadmap,
+                    ApiLoadOptions = await KeyService.GetApiOptions()
                 };
 
             _map1 = await Map.CreateAsync(JsRuntime, _map1ElementRef, mapOptions1);
@@ -55,11 +59,14 @@
                     },
                     MapTypeId = MapTypeId.Satellite,
                     Heading = 90,
-                    Tilt = 45
+                    Tilt = 45,
+                    ApiLoadOptions = await KeyService.GetApiOptions()
                 };
 
             _map2 = await Map.CreateAsync(JsRuntime, _map2ElementRef, mapOptions2);
         }
+        IJSObjectReference serverSideScripts = await JsRuntime.InvokeAsync<IJSObjectReference>("import", "/js/serverSideScripts.js");
+        await serverSideScripts.InvokeVoidAsync("initServerSideScript");
     }
 
     private async Task SyncBounds()

--- a/ServerSideDemo/Pages/_Host.cshtml
+++ b/ServerSideDemo/Pages/_Host.cshtml
@@ -20,6 +20,5 @@
     <script src="_framework/blazor.server.js"></script>
     <script src="https://unpkg.com/@@googlemaps/markerclusterer/dist/index.min.js"></script>
     <script src="_content/BlazorGoogleMaps/js/objectManager.js"></script>
-    <script src="js/serverSideScripts.js"></script>
 </body>
 </html>

--- a/ServerSideDemo/Startup.cs
+++ b/ServerSideDemo/Startup.cs
@@ -22,13 +22,15 @@ public class Startup
     {
         services.AddRazorPages();
         services.AddServerSideBlazor().AddHubOptions(config => config.MaximumReceiveMessageSize = 1048576);
-        services.AddBlazorGoogleMaps(opt =>
-        {
-            opt.KeyProvider = () => "AIzaSyBdkgvniMdyFPAcTlcZivr8f30iU-kn1T0";
-            opt.UseBootstrapLoader = true;
-            opt.Version = "beta";
-            opt.Libraries = "places,visualization,drawing,marker";
-        });
+
+        // Adds the service to use bootstrap loader for Google API JS. 
+        services.AddBlazorGoogleMaps("AIzaSyBdkgvniMdyFPAcTlcZivr8f30iU-kn1T0");
+        // Or manually set version and libraries for entire app:
+        //services.AddBlazorGoogleMaps(new GoogleMapsComponents.Maps.MapApiLoadOptions("AIzaSyBdkgvniMdyFPAcTlcZivr8f30iU-kn1T0")
+        //{
+        //    Version = "beta",
+        //    Libraries = "places,visualization,drawing,marker"
+        //});
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/ServerSideDemo/wwwroot/js/serverSideScripts.js
+++ b/ServerSideDemo/wwwroot/js/serverSideScripts.js
@@ -1,4 +1,4 @@
-﻿function initMapLegend() {
+﻿export function initMapLegend() {
     var iconBase = 'https://maps.google.com/mapfiles/kml/shapes/';
     var icons = {
         parking: {
@@ -26,95 +26,96 @@
     }
 }
 
-google.maps.Polyline.prototype.AddListeners = function () {
-    // getpath
-    console.log('Add Listeners Called.');
-    var poly = this;
-    var path = this.getPath();
+export function initServerSideScript() {
+    google.maps.Polyline.prototype.AddListeners = function () {
+        // getpath
+        console.log('Add Listeners Called.');
+        var poly = this;
+        var path = this.getPath();
 
-    // addlistener insert_at
-    event.initEvent('insert_at', true, true);
-    google.maps.event.addListener(path, 'insert_at', function (vertex) {
-        // event auf polyline auslösen
-        console.log('Vertex ' + vertex + ' inserted to path.');
-        google.maps.event.trigger(poly, 'insert_at', vertex);
-    });
+        // addlistener insert_at
+        event.initEvent('insert_at', true, true);
+        google.maps.event.addListener(path, 'insert_at', function (vertex) {
+            // event auf polyline auslösen
+            console.log('Vertex ' + vertex + ' inserted to path.');
+            google.maps.event.trigger(poly, 'insert_at', vertex);
+        });
 
-    // addlistener set_at
-    event.initEvent('set_at', true, true);
-    google.maps.event.addListener(path, 'set_at', function (vertex) {
-        // event auf polyline auslösen
-        console.log('Vertex ' + vertex + ' set on path.');
-        google.maps.event.trigger(poly, 'set_at', vertex);
-    });
+        // addlistener set_at
+        event.initEvent('set_at', true, true);
+        google.maps.event.addListener(path, 'set_at', function (vertex) {
+            // event auf polyline auslösen
+            console.log('Vertex ' + vertex + ' set on path.');
+            google.maps.event.trigger(poly, 'set_at', vertex);
+        });
 
-    // addlistener remove_at
-    event.initEvent('remove_at', true, true);
-    google.maps.event.addListener(path, 'remove_at', function (vertex) {
-        // event auf polyline auslösen
-        console.log('Vertex ' + vertex + ' removed from path.');
-        google.maps.event.trigger(poly, 'remove_at', vertex);
-    });
-}
-google.maps.Polygon.prototype.AddListeners = function () {
-    // getpath
-    console.log('Add Listeners Called.');
-    var poly = this;
-    var path = this.getPath();
-
-    // addlistener insert_at
-    event.initEvent('insert_at', true, true);
-    google.maps.event.addListener(path, 'insert_at', function (vertex) {
-        // event auf polyline auslösen
-        console.log('Vertex ' + vertex + ' inserted to path.');
-        google.maps.event.trigger(poly, 'insert_at', vertex);
-    });
-
-    // addlistener set_at
-    event.initEvent('set_at', true, true);
-    google.maps.event.addListener(path, 'set_at', function (vertex) {
-        // event auf polyline auslösen
-        console.log('Vertex ' + vertex + ' set on path.');
-        google.maps.event.trigger(poly, 'set_at', vertex);
-    });
-
-    // addlistener remove_at
-    event.initEvent('remove_at', true, true);
-    google.maps.event.addListener(path, 'remove_at', function (vertex) {
-        // event auf polyline auslösen
-        console.log('Vertex ' + vertex + ' removed from path.');
-        google.maps.event.trigger(poly, 'remove_at', vertex);
-    });
-}
-
-window.customRendererLib = {
-    interpolatedRenderer: {
-        render: function ({ count, position }, stats) {
-            let countText;
-            try {
-                let formatter = Intl.NumberFormat('en', { notation: 'compact' });
-                countText = formatter.format(count);
-            } catch {
-                countText = String(count);
-            }
-
-            // create marker using svg icon
-            return new google.maps.Marker({
-                position,
-                icon: {
-                    url: "data:image/svg+xml;base64,CiAgPHN2ZyBmaWxsPSIjMDAwMGZmIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNDAgMjQwIj4KICAgIDxjaXJjbGUgY3g9IjEyMCIgY3k9IjEyMCIgb3BhY2l0eT0iLjYiIHI9IjcwIiAvPgogICAgPGNpcmNsZSBjeD0iMTIwIiBjeT0iMTIwIiBvcGFjaXR5PSIuMyIgcj0iOTAiIC8+CiAgICA8Y2lyY2xlIGN4PSIxMjAiIGN5PSIxMjAiIG9wYWNpdHk9Ii4yIiByPSIxMTAiIC8+CiAgPC9zdmc+",
-                    scaledSize: new google.maps.Size(50, 50),
-                },
-                label: {
-                    text: countText,
-                    color: "#ffffff",
-                    fontSize: "16px",
-                    fontWeight: "bold",
-                    fontFamily: "Poppins"
-                },
-                // adjust zIndex to be above other markers
-                zIndex: Number(google.maps.Marker.MAX_ZINDEX) + count,
-            });
-        },
+        // addlistener remove_at
+        event.initEvent('remove_at', true, true);
+        google.maps.event.addListener(path, 'remove_at', function (vertex) {
+            // event auf polyline auslösen
+            console.log('Vertex ' + vertex + ' removed from path.');
+            google.maps.event.trigger(poly, 'remove_at', vertex);
+        });
     }
-};
+    google.maps.Polygon.prototype.AddListeners = function () {
+        // getpath
+        console.log('Add Listeners Called.');
+        var poly = this;
+        var path = this.getPath();
+
+        // addlistener insert_at
+        event.initEvent('insert_at', true, true);
+        google.maps.event.addListener(path, 'insert_at', function (vertex) {
+            // event auf polyline auslösen
+            console.log('Vertex ' + vertex + ' inserted to path.');
+            google.maps.event.trigger(poly, 'insert_at', vertex);
+        });
+
+        // addlistener set_at
+        event.initEvent('set_at', true, true);
+        google.maps.event.addListener(path, 'set_at', function (vertex) {
+            // event auf polyline auslösen
+            console.log('Vertex ' + vertex + ' set on path.');
+            google.maps.event.trigger(poly, 'set_at', vertex);
+        });
+
+        // addlistener remove_at
+        event.initEvent('remove_at', true, true);
+        google.maps.event.addListener(path, 'remove_at', function (vertex) {
+            // event auf polyline auslösen
+            console.log('Vertex ' + vertex + ' removed from path.');
+            google.maps.event.trigger(poly, 'remove_at', vertex);
+        });
+    }
+    window.customRendererLib = {
+        interpolatedRenderer: {
+            render: function ({ count, position }, stats) {
+                let countText;
+                try {
+                    let formatter = Intl.NumberFormat('en', { notation: 'compact' });
+                    countText = formatter.format(count);
+                } catch {
+                    countText = String(count);
+                }
+
+                // create marker using svg icon
+                return new google.maps.Marker({
+                    position,
+                    icon: {
+                        url: "data:image/svg+xml;base64,CiAgPHN2ZyBmaWxsPSIjMDAwMGZmIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNDAgMjQwIj4KICAgIDxjaXJjbGUgY3g9IjEyMCIgY3k9IjEyMCIgb3BhY2l0eT0iLjYiIHI9IjcwIiAvPgogICAgPGNpcmNsZSBjeD0iMTIwIiBjeT0iMTIwIiBvcGFjaXR5PSIuMyIgcj0iOTAiIC8+CiAgICA8Y2lyY2xlIGN4PSIxMjAiIGN5PSIxMjAiIG9wYWNpdHk9Ii4yIiByPSIxMTAiIC8+CiAgPC9zdmc+",
+                        scaledSize: new google.maps.Size(50, 50),
+                    },
+                    label: {
+                        text: countText,
+                        color: "#ffffff",
+                        fontSize: "16px",
+                        fontWeight: "bold",
+                        fontFamily: "Poppins"
+                    },
+                    // adjust zIndex to be above other markers
+                    zIndex: Number(google.maps.Marker.MAX_ZINDEX) + count,
+                });
+            },
+        }
+    };
+}


### PR DESCRIPTION
This merge request implements the changes needed for issue https://github.com/rungwiroon/BlazorGoogleMaps/issues/326.

* Adds a new interface for a scoped service users can implement to provide API keys from async operations. 
* Adds a very basic default implementation of the service that users with single API keys can use as before.
* Updates ServerSideDemo to load serverSideScripts.js through JSInterop import command since bootstrapping loads the api after `<link>` tags are evaluated. 