### PR TITLE
Adding ability to make AdvancedMarkerElement Glyphs HTML content.

### DIFF
--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -284,7 +284,14 @@
 
                     let glyph = content.glyph;
                     if (glyph) {
-                        pin.glyph = glyph.startsWith("http") ? new URL(glyph) : glyph;
+                        const isGlyphHtmlContent = typeof glyph === 'string' && glyph.startsWith("<");
+                        if (isGlyphHtmlContent) {
+                            let template = document.createElement('div');
+                            template.innerHTML = glyph.trim();
+                            pin.glyph = template;
+                        } else {
+                            pin.glyph = glyph.startsWith("http") ? new URL(glyph) : glyph;
+                        }
                     }
 
                     return pin.element;


### PR DESCRIPTION
I had mentioned in this comment: https://github.com/rungwiroon/BlazorGoogleMaps/issues/338#issuecomment-2267200750
I was unable to set PinElement Glyphs to HTML content properly.

After looking through the updates to objectManager.js in this commit: https://github.com/rungwiroon/BlazorGoogleMaps/commit/01fd96e93b11a56c341940f6fd95a069847e2eb5

I was able to understand that my suspicion was correct and only image URLs and text were currently supported.

I copied the above code for making an HTML element for pins to allow the same for PinElement Glyphs and it worked fine.

Before:
![image](https://github.com/user-attachments/assets/948df81d-3db6-4ce8-9a0a-e189edf77d14)
After:
![image](https://github.com/user-attachments/assets/4f992962-7028-41df-bfd6-930ff1b5583e)

First PR to this repo and I definitely don't understand everything going on in here, but was able to piece enough together here. I also tried to follow the codebase conventions. Feel free to make any additional modifications you see fit to get this feature in.