### PR TITLE
Improve disposing of mapObjects by making sure that guidString is registered for objects

### DIFF
--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -30,6 +30,16 @@
     let controlParents = {};
     const dateFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 
+
+    // Add the object to the map for "managed" objects, tries to set the guidString to 
+    // be able to dispose of them later on
+    function addMapObject(uuid, obj) {
+        if ("set" in obj) {
+            obj.set("guidString", uuid);
+        }
+        mapObjects[uuid] = obj;
+    }
+    
     //Strip circular dependencies, map object and functions
     //https://stackoverflow.com/questions/11616630/how-can-i-print-a-circular-structure-in-a-json-like-format
     const getCircularReplacer = () => {
@@ -343,12 +353,7 @@
                 let constructor = stringToFunction(functionName);
                 let obj = new constructor(...args2);
                 let guid = args[0];
-
-                if ("set" in obj) {
-                    obj.set("guidString", guid);
-                }
-
-                mapObjects[guid] = obj;
+                addMapObject(guid, obj)
             },
 
             //Used to create multiple objects of the same type passing a set of creation parameters coherent 
@@ -373,12 +378,7 @@
                     }
 
                     let obj = new constructor(constructorArgs);
-
-                    if ("set" in obj) {
-                        obj.set("guidString", guids[i]);
-                    }
-
-                    mapObjects[guids[i]] = obj;
+                    addMapObject(guids[i], obj);
                 }
             },
 
@@ -390,7 +390,7 @@
                 }
 
                 mapObjects = mapObjects || [];
-                mapObjects[guid] = obj;
+                addMapObject(guid, obj);
 
                 return guid;
             },
@@ -603,12 +603,12 @@
 
                         case "getProjection":
                             const projection = obj[functionToInvoke](...formattedArgs);
-                            mapObjects[restArgs[0]] = projection;
+                            addMapObject(restArgs[0], projection);
                             return;
 
                         case "createPath":
                             const pathProjection = obj.getPath();
-                            mapObjects[restArgs[0]] = pathProjection;
+                            addMapObject(restArgs[0], pathProjection);
                             return;
 
                         case "fromLatLngToPoint":
@@ -709,13 +709,11 @@
 
                 return results;
             },
-
-                        invokeWithReturnedObjectRef: async function (args) {
+            invokeWithReturnedObjectRef: async function (args) {
                 const result = await blazorGoogleMaps.objectManager.invoke(args);
                 const uuid = uuidv4();
-
                 // This is needed to be able to remove events from map
-                mapObjects[uuid] = result;
+                addMapObject(uuid, result)
 
                 return uuid;
             },
@@ -725,7 +723,7 @@
 
                 google.maps.event.addListener(drawingManager, "overlaycomplete", event => {
                     const overlayUuid = uuidv4();
-                    mapObjects[overlayUuid] = event.overlay;
+                    addMapObject(overlayUuid, event.overlay)
 
                     const returnObj = extendableStringify([{ type: event.type, uuid: overlayUuid.toString() }]);
 
@@ -782,8 +780,8 @@
                 const obj = mapObjects[objectId];
                 const result = obj?.[property];
                 const uuid = uuidv4();
-
-                mapObjects[uuid] = result;
+                
+                addMapObject(uuid, result)
 
                 return uuid;
             },
@@ -861,12 +859,7 @@
                             markers: newMarkers
                         });
                 */
-
-                if ("set" in markerCluster) {
-                    markerCluster.set("guidString", guid);
-                }
-
-                mapObjects[guid] = markerCluster;
+                addMapObject(guid, markerCluster)
             },
 
             removeClusteringMarkers(guid, markers, noDraw) {

--- a/ServerSideDemo/Pages/MapMarker.razor
+++ b/ServerSideDemo/Pages/MapMarker.razor
@@ -1,5 +1,6 @@
 ﻿@page "/mapMarker"
 @using GoogleMapsComponents
+@implements IDisposable
 
 <h1>Google Map Markers</h1>
 

--- a/ServerSideDemo/Pages/MapMarker.razor.cs
+++ b/ServerSideDemo/Pages/MapMarker.razor.cs
@@ -349,5 +349,9 @@ public partial class MapMarker
         await _map1.InteropObject.FitBounds(boundsLiteral, OneOf.OneOf<int, Padding>.FromT0(5));
     }
 
-
+    public void Dispose()
+    {
+        // Just to show that _bounds can be removed, but has be done manually since it doesn't relate to the map
+        _map1.Dispose();
+    }
 }


### PR DESCRIPTION
Simply make sure to always register the guidString, that we we can clean them up when disposing. Noticed that the MapData was not disposed, but it was connected to the map. This solved this issue and should solve more missing disposes (projection?) 😄 