### PR TITLE
Fix map items dispose issue

### DIFF
--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -30,6 +30,16 @@
     let controlParents = {};
     const dateFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 
+
+    // Add the object to the map for "managed" objects, tries to set the guidString to 
+    // be able to dispose of them later on
+    function addMapObject(uuid, obj) {
+        if (obj && typeof(obj) === "object" && "set" in obj) {
+            obj.set("guidString", uuid);
+        }
+        mapObjects[uuid] = obj;
+    }
+    
     //Strip circular dependencies, map object and functions
     //https://stackoverflow.com/questions/11616630/how-can-i-print-a-circular-structure-in-a-json-like-format
     const getCircularReplacer = () => {
@@ -345,12 +355,7 @@
                 let constructor = stringToFunction(functionName);
                 let obj = new constructor(...args2);
                 let guid = args[0];
-
-                if ("set" in obj) {
-                    obj.set("guidString", guid);
-                }
-
-                mapObjects[guid] = obj;
+                addMapObject(guid, obj)
             },
 
             //Used to create multiple objects of the same type passing a set of creation parameters coherent 
@@ -375,12 +380,7 @@
                     }
 
                     let obj = new constructor(constructorArgs);
-
-                    if ("set" in obj) {
-                        obj.set("guidString", guids[i]);
-                    }
-
-                    mapObjects[guids[i]] = obj;
+                    addMapObject(guids[i], obj);
                 }
             },
 
@@ -392,7 +392,7 @@
                 }
 
                 mapObjects = mapObjects || [];
-                mapObjects[guid] = obj;
+                addMapObject(guid, obj);
 
                 return guid;
             },
@@ -605,12 +605,12 @@
 
                         case "getProjection":
                             const projection = obj[functionToInvoke](...formattedArgs);
-                            mapObjects[restArgs[0]] = projection;
+                            addMapObject(restArgs[0], projection);
                             return;
 
                         case "createPath":
                             const pathProjection = obj.getPath();
-                            mapObjects[restArgs[0]] = pathProjection;
+                            addMapObject(restArgs[0], pathProjection);
                             return;
 
                         case "fromLatLngToPoint":
@@ -624,7 +624,7 @@
 
                         case "getPaths":
                             const paths = obj[functionToInvoke](...formattedArgs);
-                            return paths.map(coords => coords.getArray());
+                            return paths.getArray().map(coords => coords.getArray());
 
                         case "removeAllFeatures":
                             obj.forEach(feature => obj.remove(feature));
@@ -711,13 +711,11 @@
 
                 return results;
             },
-
             invokeWithReturnedObjectRef: async function (args) {
                 const result = await blazorGoogleMaps.objectManager.invoke(args);
                 const uuid = uuidv4();
-
                 // This is needed to be able to remove events from map
-                mapObjects[uuid] = result;
+                addMapObject(uuid, result)
 
                 return uuid;
             },
@@ -727,7 +725,7 @@
 
                 google.maps.event.addListener(drawingManager, "overlaycomplete", event => {
                     const overlayUuid = uuidv4();
-                    mapObjects[overlayUuid] = event.overlay;
+                    addMapObject(overlayUuid, event.overlay)
 
                     const returnObj = extendableStringify([{ type: event.type, uuid: overlayUuid.toString() }]);
 
@@ -784,8 +782,8 @@
                 const obj = mapObjects[objectId];
                 const result = obj?.[property];
                 const uuid = uuidv4();
-
-                mapObjects[uuid] = result;
+                
+                addMapObject(uuid, result)
 
                 return uuid;
             },
@@ -863,12 +861,7 @@
                             markers: newMarkers
                         });
                 */
-
-                if ("set" in markerCluster) {
-                    markerCluster.set("guidString", guid);
-                }
-
-                mapObjects[guid] = markerCluster;
+                addMapObject(guid, markerCluster)
             },
 
             removeClusteringMarkers(guid, markers, noDraw) {

--- a/ServerSideDemo/Pages/MapEvents.razor
+++ b/ServerSideDemo/Pages/MapEvents.razor
@@ -2,6 +2,8 @@
 @using GoogleMapsComponents
 @using GoogleMapsComponents.Maps
 
+@implements IAsyncDisposable
+
 <h1>Map Events</h1>
 
 <GoogleMap @ref="@_map1" Id="map1" Options="@_mapOptions" OnAfterInit="@OnAfterInitAsync">
@@ -338,5 +340,13 @@
         _labelText = _markers.Any() ? await _markers.Peek().GetLabelText() : "";
     }
 
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var marker in _markers)
+        {
+            await marker.DisposeAsync();
+        }
+        await _map1.DisposeAsync();
+    }
 
 }

--- a/ServerSideDemo/Pages/MapPolyline.razor
+++ b/ServerSideDemo/Pages/MapPolyline.razor
@@ -3,6 +3,8 @@
 @using GoogleMapsComponents.Maps
 @inject IJSRuntime JsRuntime
 
+@implements IAsyncDisposable
+
 <h1>Polylines</h1>
 
 <GoogleMap @ref="@_map1" Id="map1" Options="@_mapOptions" OnAfterInit="async () => await OnAfterMapInit()"></GoogleMap>
@@ -362,6 +364,15 @@
         {
             await polygon.SetMap(null);
         }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _map1.DisposeAsync();
+        if (_polyline != null) await _polyline.DisposeAsync();
+        if (_polygon != null) await _polygon.DisposeAsync();
+        if (_rectangle != null) await _rectangle.DisposeAsync();
+        if (_circle != null) await _circle.DisposeAsync();
     }
 
 }

--- a/ServerSideDemo/Pages/MapServices.razor
+++ b/ServerSideDemo/Pages/MapServices.razor
@@ -3,6 +3,8 @@
 @using GoogleMapsComponents.Maps
 @using GoogleMapsComponents.Maps.Places
 
+@implements IAsyncDisposable
+
 @*
     The code for this sample was taken from below on 09/02/2020:
     https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/examples/places-autocomplete


### PR DESCRIPTION
Sorry for breaking last time, apperently my JS knowledge is limited when it comes to this stuff 😆 

Now we make sure that the item is a object (which should have support for the "in" check). Added some more disposes to server side pages to make sure that we cleanup. Also fixes some issue with the polygon "getPaths" that I noticed when testing.

Fixes #360 