### PR TITLE
Allow for creating MarkerComponent without "targeting" a map

### DIFF
--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -945,10 +945,6 @@
                 }
 
                 const map = mapObjects[mapId];
-                if (!map) {
-                    console.error(`Map with ID ${mapId} not found.`);
-                    return;
-                }
 
                 const content = document.querySelector(`#${componentId}`);
                 if (!content) {


### PR DESCRIPTION
Tiny change to allow markers to be created without a matching Map.

This is pretty important in my case since I want the advanced markers to be created (as in google taking control of the content) but I dont want them to show up on the map just yet, since they are clustered. If I add them to the map instantly all the markers blink and then are put into the cluster. 

Thanks for merging and I like the other changes you made, made it much clearer how the marker control works 🚀 