### PR TITLE
Added support for EventCallback

### DIFF
--- a/GoogleMapsComponents/Extensions/JsArgumentExtensions.cs
+++ b/GoogleMapsComponents/Extensions/JsArgumentExtensions.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using OneOf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleMapsComponents.Extensions;
+internal static class JsArgumentExtensions
+{
+    private static string? GetEnumValue(object? enumItem)
+    {
+        //what happens if enumItem is null.
+        //Shouldnt we take 0 value of enum
+        //Also is it even possible to have null enumItem
+        //So far looks like only MapLegend Add controll reach here
+        if (enumItem == null)
+        {
+            return null;
+        }
+
+        if (enumItem is not Enum enumItem2)
+        {
+            return enumItem.ToString();
+        }
+
+        var memberInfo = enumItem2.GetType().GetMember(enumItem2.ToString());
+        if (memberInfo.Length == 0)
+        {
+            return null;
+        }
+
+        foreach (var attr in memberInfo[0].GetCustomAttributes(false))
+        {
+            if (attr is EnumMemberAttribute val)
+            {
+                return val.Value;
+            }
+        }
+
+        return null;
+    }
+
+    internal static DotNetObjectReference<JsAsyncCallableAction<T>> MakeCallbackJsFriendly<T>(this IJSRuntime jsRuntime, EventCallback<T> callback)
+    {
+        return DotNetObjectReference.Create(new JsAsyncCallableAction<T>(jsRuntime, callback));
+    }
+
+    internal static IEnumerable<object> MakeArgJsFriendly(this IJSRuntime jsRuntime, IEnumerable<object?> args)
+    {
+        var jsFriendlyArgs = args
+            .Select(arg =>
+            {
+                if (arg == null)
+                {
+                    return arg;
+                }
+
+                if (arg is IOneOf oneof)
+                {
+                    arg = oneof.Value;
+                }
+
+                var argType = arg.GetType();
+
+                switch (arg)
+                {
+                    case Enum: return GetEnumValue(arg);
+                    case ElementReference _:
+                    case string _:
+                    case int _:
+                    case long _:
+                    case double _:
+                    case float _:
+                    case decimal _:
+                    case DateTime _:
+                    case bool _:
+                        return arg;
+                    case Action action:
+                        return DotNetObjectReference.Create(new JsCallableAction(jsRuntime, action));
+                    case EventCallback callback:
+                        return DotNetObjectReference.Create(new JsAsyncCallableAction(callback));
+                    default:
+                        {
+                            if (argType.IsGenericType && argType.GetGenericTypeDefinition() == typeof(Action<>))
+                            {
+                                var genericArguments = argType.GetGenericArguments();
+
+                                //Debug.WriteLine($"Generic args : {genericArguments.Count()}");
+
+                                return DotNetObjectReference.Create(new JsCallableAction(jsRuntime, (Delegate)arg, genericArguments));
+                            }
+
+                            switch (arg)
+                            {
+                                case JsCallableAction _:
+                                    return DotNetObjectReference.Create(arg);
+                                case IJsObjectRef jsObjectRef:
+                                    {
+                                        //Debug.WriteLine("Serialize IJsObjectRef");
+
+                                        var guid = jsObjectRef.Guid;
+                                        return JsonExtensions.SerializeObject(new JsObjectRef1(guid));
+                                    }
+                                default:
+                                    return JsonExtensions.SerializeObject(arg);
+                            }
+                        }
+                }
+            });
+
+        return jsFriendlyArgs;
+    }
+}

--- a/GoogleMapsComponents/Extensions/JsInvokeExtensions.cs
+++ b/GoogleMapsComponents/Extensions/JsInvokeExtensions.cs
@@ -1,0 +1,64 @@
+﻿using GoogleMapsComponents.Maps.Strings;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using OneOf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace GoogleMapsComponents.Extensions;
+internal static class JsInvokeExtensions
+{
+    internal static async Task<TRes> AddListener<TRes, T>(
+        this IJSRuntime jsRuntime,
+        EventCallback<T> callback, 
+        params object?[] args)
+    {
+        var callBackJs = jsRuntime.MakeCallbackJsFriendly(callback);
+        var jsFriendlyArgs = jsRuntime.MakeArgJsFriendly(args).Append(callBackJs);
+        
+
+        if (typeof(IJsObjectRef).IsAssignableFrom(typeof(TRes)))
+        {
+            var guid = await jsRuntime.InvokeAsync<string?>(Methods.InvokeWithReturnedObjectRef, jsFriendlyArgs);
+
+            return guid == null ? default : (TRes)JsObjectRefInstances.GetInstance(guid);
+        }
+
+        if (typeof(IOneOf).IsAssignableFrom(typeof(TRes)))
+        {
+            var resultObject = await jsRuntime.InvokeAsync<string>(Methods.InvokeWithReturnedObjectRef, jsFriendlyArgs);
+            object? result = null;
+
+            if (resultObject is string someText)
+            {
+                try
+                {
+                    var jo = JsonDocument.Parse(someText);
+                    var typeToken = jo.RootElement.GetProperty("dotnetTypeName").GetString();
+                    if (typeToken != null)
+                    {
+                        result = JsonExtensions.DeSerializeObject<TRes>(typeToken);
+                    }
+                    else
+                    {
+                        result = someText;
+                    }
+                }
+                catch
+                {
+                    result = someText;
+                }
+            }
+
+            return (TRes?)result;
+        }
+        else
+        {
+            return await jsRuntime.InvokeAsync<TRes>(Methods.InvokeWithReturnedObjectRef, jsFriendlyArgs);
+        }
+    }
+}

--- a/GoogleMapsComponents/Extensions/JsonExtensions.cs
+++ b/GoogleMapsComponents/Extensions/JsonExtensions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+using System.Threading.Tasks;
+using GoogleMapsComponents.Serialization;
+
+namespace GoogleMapsComponents.Extensions;
+internal static class JsonExtensions
+{
+    private static readonly JsonSerializerOptions Options = new JsonSerializerOptions()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    static JsonExtensions()
+    {
+        Options.Converters.Add(new OneOfConverterFactory());
+        Options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+    }
+
+    public static object? DeSerializeObject(JsonElement json, Type type)
+    {
+        var obj = json.Deserialize(type, Options);
+        return obj;
+    }
+
+    public static T? DeSerializeObject<T>(JsonElement json)
+    {
+        return json.Deserialize<T>(Options);
+    }
+
+    public static object? DeSerializeObject(string? json, Type type)
+    {
+        if (json == null)
+        {
+            return default;
+        }
+
+        var obj = JsonSerializer.Deserialize(json, type, Options);
+        return obj;
+    }
+
+    public static TObject? DeSerializeObject<TObject>(string? json)
+    {
+        if (json == null)
+        {
+            return default;
+        }
+
+        var value = JsonSerializer.Deserialize<TObject>(json, Options);
+        return value;
+    }
+
+    public static string SerializeObject(object obj)
+    {
+        var value = JsonSerializer.Serialize(obj, Options);
+        return value;
+    }
+}

--- a/GoogleMapsComponents/JsAsyncCallableAction.cs
+++ b/GoogleMapsComponents/JsAsyncCallableAction.cs
@@ -1,0 +1,56 @@
+﻿using GoogleMapsComponents.Extensions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace GoogleMapsComponents;
+
+/// <summary>
+/// A callable eventcallback from JavaScript. This doesn't accept any arguments.
+/// </summary>
+public class JsAsyncCallableAction
+{
+    private readonly EventCallback eventCallback;
+
+    public JsAsyncCallableAction(EventCallback eventCallback)
+    {
+        this.eventCallback = eventCallback;
+    }
+
+    [JSInvokable]
+    public Task Invoke(string args, string guid)
+    {
+        return eventCallback.InvokeAsync();
+    }
+}
+
+public class JsAsyncCallableAction<T>
+{
+    private readonly EventCallback<T> eventCallback;
+    private readonly IJSRuntime jsRuntime;
+    public JsAsyncCallableAction(IJSRuntime jsRuntime, EventCallback<T> eventCallback)
+    {
+        this.jsRuntime = jsRuntime;
+        this.eventCallback = eventCallback;
+    }
+
+    [JSInvokable]
+    public Task Invoke(string args, string guid)
+    {
+
+        var jElement = JsonDocument.Parse(args)
+            .RootElement
+            .EnumerateArray()
+            .FirstOrDefault();
+
+        var obj = JsonExtensions.DeSerializeObject<T>(jElement);
+        if (obj is IActionArgument actionArg)
+        {
+            actionArg.JsObjectRef = new JsObjectRef(jsRuntime, new Guid(guid));
+        }
+        return eventCallback.InvokeAsync(obj);
+    }
+}

--- a/GoogleMapsComponents/JsCallableAction.cs
+++ b/GoogleMapsComponents/JsCallableAction.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.JSInterop;
+﻿using GoogleMapsComponents.Extensions;
+using Microsoft.JSInterop;
 using System;
 using System.Linq;
 using System.Text.Json;
@@ -34,7 +35,7 @@ public class JsCallableAction
         var arguments = _argumentTypes.Zip(jArray, (type, jToken) => new { jToken, type })
             .Select(x =>
             {
-                var obj = Helper.DeSerializeObject(x.jToken, x.type);
+                var obj = JsonExtensions.DeSerializeObject(x.jToken, x.type);
                 if (obj is IActionArgument actionArg)
                 {
                     actionArg.JsObjectRef = new JsObjectRef(_jsRuntime, new Guid(guid));

--- a/GoogleMapsComponents/JsObjectRef.cs
+++ b/GoogleMapsComponents/JsObjectRef.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.JSInterop;
+﻿using GoogleMapsComponents.Extensions;
+using GoogleMapsComponents.Maps.Strings;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using OneOf;
 using System;
 using System.Collections.Generic;
@@ -267,8 +270,18 @@ public class JsObjectRef : IJsObjectRef, IDisposable
         );
     }
 
+    public async Task<JsObjectRef> AddEventCallback<T>(EventCallback<T> callback, params object[] args)
+    {
+        // invokes the function in js creating an object in the map and returns the guid of the object created for future reference
+        var guid = await _jsRuntime.AddListener<string, T>(callback, new object[] { _guid.ToString(), Methods.AddListener }.Concat(args).ToArray());
+        return new JsObjectRef(_jsRuntime, new Guid(guid));
+        //var guid = await _jsRuntime.MyInvokeAsync<string>(Methods.InvokeWithReturnedObjectRef,
+        //    new object[] { _guid.ToString(), "addListener", "eventName", (object)callback });
+    }
+
     public async Task<JsObjectRef> InvokeWithReturnedObjectRefAsync(string functionName, params object[] args)
     {
+        // invokes the function in js creating an object in the map and returns the guid of the object created for future reference
         var guid = await _jsRuntime.MyInvokeAsync<string>(
             "blazorGoogleMaps.objectManager.invokeWithReturnedObjectRef",
             new object[] { _guid.ToString(), functionName }

--- a/GoogleMapsComponents/Maps/DirectionsRenderer.cs
+++ b/GoogleMapsComponents/Maps/DirectionsRenderer.cs
@@ -1,4 +1,5 @@
-﻿using GoogleMapsComponents.Maps.Extension;
+﻿using GoogleMapsComponents.Extensions;
+using GoogleMapsComponents.Maps.Extension;
 using Microsoft.JSInterop;
 using System;
 using System.Threading.Tasks;
@@ -37,7 +38,7 @@ public class DirectionsRenderer : EventEntityBase, IDisposable
             request, directionsRequestOptions);
         try
         {
-            var dirResult = Helper.DeSerializeObject<DirectionsResult>(response);
+            var dirResult = JsonExtensions.DeSerializeObject<DirectionsResult>(response);
             return dirResult;
         }
         catch (Exception e)
@@ -84,7 +85,7 @@ public class DirectionsRenderer : EventEntityBase, IDisposable
             directionsRequestOptions);
         try
         {
-            var dirResult = Helper.DeSerializeObject<DirectionsResult>(response);
+            var dirResult = JsonExtensions.DeSerializeObject<DirectionsResult>(response);
             return dirResult;
         }
         catch (Exception e)

--- a/GoogleMapsComponents/Maps/DirectionsService.cs
+++ b/GoogleMapsComponents/Maps/DirectionsService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.JSInterop;
+﻿using GoogleMapsComponents.Extensions;
+using Microsoft.JSInterop;
 using System;
 using System.Threading.Tasks;
 
@@ -55,7 +56,7 @@ public class DirectionsService : IDisposable
 
         try
         {
-            var dirResult = Helper.DeSerializeObject<DirectionsResult>(response);
+            var dirResult = JsonExtensions.DeSerializeObject<DirectionsResult>(response);
             return dirResult;
         }
         catch (Exception e)

--- a/GoogleMapsComponents/Maps/Extension/EventEntityBase.cs
+++ b/GoogleMapsComponents/Maps/Extension/EventEntityBase.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Components;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -31,6 +32,25 @@ public abstract class EventEntityBase : IDisposable
     {
         var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
             "addListener", eventName, handler);
+
+        var eventListener = new MapEventListener(listenerRef);
+        AddEvent(eventName, eventListener);
+        return eventListener;
+    }
+
+    public async Task<MapEventListener> AddListener(string eventName, EventCallback callback)
+    {
+        var listenerRef = await _jsObjectRef.InvokeWithReturnedObjectRefAsync(
+            "addListener", eventName, callback);
+
+        var eventListener = new MapEventListener(listenerRef);
+        AddEvent(eventName, eventListener);
+        return eventListener;
+    }
+
+    public async Task<MapEventListener> AddListener<T>(string eventName, EventCallback<T> callback)
+    {
+        var listenerRef = await _jsObjectRef.AddEventCallback(callback, eventName);
 
         var eventListener = new MapEventListener(listenerRef);
         AddEvent(eventName, eventListener);

--- a/GoogleMapsComponents/Maps/Marker.cs
+++ b/GoogleMapsComponents/Maps/Marker.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.JSInterop;
+﻿using GoogleMapsComponents.Extensions;
+using Microsoft.JSInterop;
 using OneOf;
 using System.Threading.Tasks;
 
@@ -81,7 +82,7 @@ public class Marker : ListableEntityBase<MarkerOptions>, IMarker
             && markerLabel.AsT0.Contains("GoogleMapsComponents.Maps.MarkerLabel"))
         {
             var stringValue = markerLabel.AsT0;
-            var markerLabelObj = Helper.DeSerializeObject<MarkerLabel>(stringValue);
+            var markerLabelObj = JsonExtensions.DeSerializeObject<MarkerLabel>(stringValue);
             if (markerLabelObj != null)
             {
                 return markerLabelObj;

--- a/GoogleMapsComponents/Maps/Strings/Methods.cs
+++ b/GoogleMapsComponents/Maps/Strings/Methods.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleMapsComponents.Maps.Strings;
+internal static class Methods
+{
+    internal static string AddListener = "addListener";
+    internal static string InvokeWithReturnedObjectRef = "blazorGoogleMaps.objectManager.invokeWithReturnedObjectRef";
+}

--- a/ServerSideDemo/Pages/MapEvents.razor
+++ b/ServerSideDemo/Pages/MapEvents.razor
@@ -49,14 +49,17 @@
         //Debug.WriteLine("Start OnAfterRenderAsync");
 
         await _map1.InteropObject.AddListener("bounds_changed", OnBoundsChanged);
+        await _map1.InteropObject.AddListener("bounds_changed", new EventCallbackFactory().Create(this, OnBoundsChangedAsync));
         //Once can be removed before it is triggered, this shows that it is not triggered
         var reference = await _map1.InteropObject.AddListenerOnce("rightclick", OnBoundsChangedOnce);
         await reference.RemoveAsync();
-        
+
 
         await _map1.InteropObject.AddListener("center_changed", OnCenterChanged);
 
         await _map1.InteropObject.AddListener<MouseEvent>("click", async (e) => await OnClick(e));
+
+        await _map1.InteropObject.AddListener<MouseEvent>("click", new EventCallbackFactory().Create<MouseEvent>(this, OnClickAsync));
 
         await _map1.InteropObject.AddListener("dblclick", OnDoubleClick);
 
@@ -70,7 +73,7 @@
 
         await _map1.InteropObject.AddListener("idle", OnIdle);
 
-        
+
     }
 
     private void OnBoundsChanged()
@@ -82,7 +85,15 @@
 
         StateHasChanged();
     }
-    
+
+    private async Task OnBoundsChangedAsync(){
+        await Task.Delay(1000);
+        _events.Insert(0, "Bounds changed async.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+    }
+
     private void OnBoundsChangedOnce()
     {
         _events.Insert(0, "Bounds changed once.");
@@ -106,6 +117,22 @@
         //Console.WriteLine("Click.");
 
         _events.Insert(0, $"Click {e.LatLng}.");
+        _events = _events.Take(100).ToList();
+
+        StateHasChanged();
+
+        if (DisablePoiInfoWindow)
+        {
+            await e.Stop();
+        }
+    }
+
+    private async Task OnClickAsync(MouseEvent e)
+    {
+        //Console.WriteLine("Click.");
+
+        await Task.Delay(100);
+        _events.Insert(0, $"Click async {e.LatLng}.");
         _events = _events.Take(100).ToList();
 
         StateHasChanged();


### PR DESCRIPTION
Added support for EventCallback, in adition to the already existing support for Action.

This allows for a better support of Blazor components like wrapping the maps in custom Razor components where EventCallbacks can be exposed as parameters and the use of async methods is transparent.

I am also trying to move all the magic strings into a single c# file.