### PR TITLE
Update Legacy places.Autocomplete -> places.PlaceAutocompleteElement

### DIFF
--- a/GoogleMapsComponents/Maps/Places/Autocomplete.cs
+++ b/GoogleMapsComponents/Maps/Places/Autocomplete.cs
@@ -10,7 +10,7 @@ public class Autocomplete : EventEntityBase
 {
     public static async Task<Autocomplete> CreateAsync(IJSRuntime jsRuntime, ElementReference inputField, AutocompleteOptions? opts = null)
     {
-        var jsObjectRef = await JsObjectRef.CreateAsync(jsRuntime, "google.maps.places.Autocomplete", inputField, opts);
+        var jsObjectRef = await JsObjectRef.CreateAsync(jsRuntime, "google.maps.places.PlaceAutocompleteElement", inputField, opts);
         var obj = new Autocomplete(jsObjectRef);
 
         return obj;


### PR DESCRIPTION
As of March 1st, 2025, google.maps.places.Autocomplete is not available to new customers. Please use google.maps.places.PlaceAutocompleteElement instead. At this time, google.maps.places.Autocomplete is not scheduled to be discontinued, but google.maps.places.PlaceAutocompleteElement is recommended over google.maps.places.Autocomplete. While google.maps.places.Autocomplete will continue to receive bug fixes for any major regressions, existing bugs in google.maps.places.Autocomplete will not be addressed. At least 12 months notice will be given before support is discontinued. Please see https://developers.google.com/maps/legacy for additional details and https://developers.google.com/maps/documentation/javascript/places-migration-overview for the migration guide.