### PR TITLE
Revert "Update Legacy places.Autocomplete -> places.PlaceAutocompleteElement"

### DIFF
--- a/GoogleMapsComponents/Maps/Places/Autocomplete.cs
+++ b/GoogleMapsComponents/Maps/Places/Autocomplete.cs
@@ -10,7 +10,7 @@ public class Autocomplete : EventEntityBase
 {
     public static async Task<Autocomplete> CreateAsync(IJSRuntime jsRuntime, ElementReference inputField, AutocompleteOptions? opts = null)
     {
-        var jsObjectRef = await JsObjectRef.CreateAsync(jsRuntime, "google.maps.places.PlaceAutocompleteElement", inputField, opts);
+        var jsObjectRef = await JsObjectRef.CreateAsync(jsRuntime, "google.maps.places.Autocomplete", inputField, opts);
         var obj = new Autocomplete(jsObjectRef);
 
         return obj;


### PR DESCRIPTION
Reverts rungwiroon/BlazorGoogleMaps#416

@valentasm1 After testing, seems like there is compatibility issues with the past places.Autocomplete - as the new places.PlaceAutocompleteElement does not take in Input + opts and instead only takes in Opts and is it's own element.

like this for example:

<gmp-place-autocomplete
@ref="autocompleteElement"
included-region-codes="au"
@on gmp-select="OnSelected">

Since it is not compatible with previous element, I think its best to revert back to places.Autocomplete until it can be properly implemented.

