### PR TITLE
Support reusing the map to prevent memory leak & billing increase

### DIFF
--- a/ClientSideDemo/Pages/AdvancedMarkerComponent.razor
+++ b/ClientSideDemo/Pages/AdvancedMarkerComponent.razor
@@ -63,7 +63,9 @@
         CameraControl = true,
         MapTypeId = MapTypeId.Roadmap,
         // ColorScheme = ColorScheme.Dark,
-        MapId = "e5asd595q2121"
+        MapId = "e5asd595q2121",
+        Recycle = true,
+        CacheKey = "coolmap"
     };
         
     async Task InvokeClustering()

--- a/GoogleMapsComponents/Maps/MapOptions.cs
+++ b/GoogleMapsComponents/Maps/MapOptions.cs
@@ -284,4 +284,18 @@ public class MapOptions
     /// page without changing embedded JSON styling in your application code.
     /// </summary>
     public string? MapId { get; set; }
+    
+    /// <summary>
+    /// Optional key to allow for the map to be reused. The key will cause maps loaded with this key to be reused,
+    /// allowing you to store multiple instances. This works in combination with <see cref="Recycle"/> to store the
+    /// map and map div when disposed. When the map is then loaded it will reuse the same instance and div
+    /// to prevent memory leaks and to prevent more billing (Each map is billed on creation).
+    /// </summary>
+    public string? CacheKey { get; set; }
+    /// <summary>
+    /// Optional boolean to allow for the map to be reused.  This works in combination with <see cref="CacheKey"/> to
+    /// store the map and map div when disposed. When the map is then loaded it will reuse the same instance and div
+    /// to prevent memory leaks and to prevent more billing (Each map is billed on creation).
+    /// </summary>
+    public bool Recycle { get; set; }
 }

--- a/ServerSideDemo/Pages/AdvancedMarkerComponent.razor
+++ b/ServerSideDemo/Pages/AdvancedMarkerComponent.razor
@@ -62,7 +62,9 @@
         CameraControl = true,
         MapTypeId = MapTypeId.Roadmap,
         // ColorScheme = ColorScheme.Dark,
-        MapId = "e5asd595q2121"
+        MapId = "e5asd595q2121",
+        Recycle = true,
+        CacheKey = "coolmap"
     };
 
     private async Task AddMarker()


### PR DESCRIPTION
This is heavy based on: https://github.com/xkjyeah/vue-google-maps/pull/652

Works very well in my case but there might be some issues (overlays etc will probably need to be cleaned up), maybe I should add a way for users to create their own extensions JS method which will be called (if specified) when we dispose the map, that would allow the user to remove traffic layers etc which have been added seperatly.