### PR TITLE
Fix issue where the pooling might race a new initialisation

### DIFF
--- a/GoogleMapsComponents/wwwroot/js/objectManager.js
+++ b/GoogleMapsComponents/wwwroot/js/objectManager.js
@@ -388,7 +388,7 @@
                     } else {
                         obj = new google.maps.Map(targetElement, options)
                         if (recycleKey)
-                            mapObjects[recycleKey] = { map: obj }
+                            mapObjects[recycleKey] = { map: obj, div: obj.getDiv() }
                     }
                     // Tag the map with the recycle key to be able to retrieve it in dispose...
                     if (recycleKey && obj && typeof(obj) === "object" && "set" in obj) {


### PR DESCRIPTION
Seems that I might have missed a case like this, this is a simple enough fix. The div is still referenced so not really sure that we need to handle storing it in dispose but seems that it won't hurt.