### PR TITLE
Converted LatLngLiteral's into a readonly struct for performance/memory

### DIFF
--- a/ClientSideDemo/Pages/AdvancedMarkerComponent.razor
+++ b/ClientSideDemo/Pages/AdvancedMarkerComponent.razor
@@ -53,11 +53,7 @@
     private readonly MapOptions _mapOptions = new MapOptions()
     {
         Zoom = 13,
-        Center = new LatLngLiteral()
-        {
-            Lat = 13.505892,
-            Lng = 100.8162
-        },
+        Center = new LatLngLiteral(13.505892d, 100.8162d),
         IsFractionalZoomEnabled = false,
         HeadingInteractionEnabled = true,
         CameraControl = true,

--- a/ClientSideDemo/Pages/MapAdvancedMarkerPage.razor
+++ b/ClientSideDemo/Pages/MapAdvancedMarkerPage.razor
@@ -28,14 +28,10 @@
     private GoogleMap _map1 = null!;
     private int _counter;
     const string Svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"56\" height=\"56\" viewBox=\"0 0 56 56\" fill=\"none\">\r\n  <rect width=\"56\" height=\"56\" rx=\"28\" fill=\"#7837FF\"></rect>\r\n  <path d=\"M46.0675 22.1319L44.0601 22.7843\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path>\r\n  <path d=\"M11.9402 33.2201L9.93262 33.8723\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path>\r\n  <path d=\"M27.9999 47.0046V44.8933\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path>\r\n  <path d=\"M27.9999 9V11.1113\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path>\r\n  <path d=\"M39.1583 43.3597L37.9186 41.6532\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path>\r\n  <path d=\"M16.8419 12.6442L18.0816 14.3506\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path>\r\n  <path d=\"M9.93262 22.1319L11.9402 22.7843\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path>\r\n  <path d=\"M46.0676 33.8724L44.0601 33.2201\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path>\r\n  <path d=\"M39.1583 12.6442L37.9186 14.3506\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path>\r\n  <path d=\"M16.8419 43.3597L18.0816 41.6532\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path>\r\n  <path d=\"M28 39L26.8725 37.9904C24.9292 36.226 23.325 34.7026 22.06 33.4202C20.795 32.1378 19.7867 30.9918 19.035 29.9823C18.2833 28.9727 17.7562 28.0587 17.4537 27.2401C17.1512 26.4216 17 25.5939 17 24.7572C17 23.1201 17.5546 21.7513 18.6638 20.6508C19.7729 19.5502 21.1433 19 22.775 19C23.82 19 24.7871 19.2456 25.6762 19.7367C26.5654 20.2278 27.34 20.9372 28 21.8649C28.77 20.8827 29.5858 20.1596 30.4475 19.6958C31.3092 19.2319 32.235 19 33.225 19C34.8567 19 36.2271 19.5502 37.3362 20.6508C38.4454 21.7513 39 23.1201 39 24.7572C39 25.5939 38.8488 26.4216 38.5463 27.2401C38.2438 28.0587 37.7167 28.9727 36.965 29.9823C36.2133 30.9918 35.205 32.1378 33.94 33.4202C32.675 34.7026 31.0708 36.226 29.1275 37.9904L28 39Z\" fill=\"#FF7878\"></path>\r\n</svg>";
-    private readonly MapOptions _mapOptions = new MapOptions()
+    private readonly MapOptions _mapOptions = new()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Center = new LatLngLiteral(13.505892d, 100.8162d),
             IsFractionalZoomEnabled = false,
             HeadingInteractionEnabled = true,
             CameraControl = true,
@@ -44,8 +40,8 @@
             MapId = "e5asd595q2121"
         };
     private LatLngBounds _bounds = null!;
-    private readonly List<String> _events = new List<String>();
-    private readonly Stack<AdvancedMarkerElement> _markers = new Stack<AdvancedMarkerElement>();
+    private readonly List<String> _events = new();
+    private readonly Stack<AdvancedMarkerElement> _markers = new();
     private AdvancedMarkerElementList? _markerElementList;
 
     [Inject]
@@ -83,19 +79,19 @@
     {
         var coordinates = new List<LatLngLiteral>()
         {
-            new LatLngLiteral(){ Lng = 145.128708, Lat = -37.759859 },
-            new LatLngLiteral(){ Lng = 145.133858, Lat = -37.765015 },
-            new LatLngLiteral(){ Lng = 145.143299, Lat = -37.770104 },
-            new LatLngLiteral(){ Lng = 145.145187, Lat = -37.7737 },
-            new LatLngLiteral(){ Lng = 145.137978, Lat = -37.774785 },
-            new LatLngLiteral(){ Lng = 144.968119, Lat = -37.819616 },
-            new LatLngLiteral(){ Lng = 144.695692, Lat = -38.330766 },
-            new LatLngLiteral(){ Lng = 175.053218, Lat = -39.927193 },
-            new LatLngLiteral(){ Lng = 174.865694, Lat = -41.330162 },
-            new LatLngLiteral(){ Lng = 147.439506, Lat = -42.734358 },
-            new LatLngLiteral(){ Lng = 147.501315, Lat = -42.734358 },
-            new LatLngLiteral(){ Lng = 147.438, Lat = -42.735258 },
-            new LatLngLiteral(){ Lng = 170.463352, Lat = -43.999792 },
+            new(145.128708, -37.759859),
+            new(145.133858, -37.765015),
+            new(145.143299,  -37.770104),
+            new(145.145187, -37.7737),
+            new(145.137978, -37.774785),
+            new(144.968119,  -37.819616),
+            new(144.695692,-38.330766),
+            new(175.053218, -39.927193),
+            new(174.865694, -41.330162 ),
+            new(147.439506, -42.734358),
+            new(147.501315, -42.734358),
+            new(147.438, -42.735258),
+            new(170.463352, -43.999792),
         };
         await AddMarkersGroup(coordinates);
     }
@@ -104,23 +100,23 @@
     {
         var coordinates = new List<LatLngLiteral>()
         {
-            new LatLngLiteral(){ Lng = 147.154312, Lat = -31.56391 },
-            new LatLngLiteral(){ Lng = 150.363181, Lat = -33.718234 },
-            new LatLngLiteral(){ Lng = 150.371124, Lat = -33.727111 },
-            new LatLngLiteral(){ Lng = 151.209834, Lat = -33.848588 },
-            new LatLngLiteral(){ Lng = 151.216968, Lat = -33.851702 },
-            new LatLngLiteral(){ Lng = 150.863657, Lat = -34.671264 },
-            new LatLngLiteral(){ Lng = 148.662905, Lat = -35.304724 },
-            new LatLngLiteral(){ Lng = 175.699196, Lat = -36.817685 },
-            new LatLngLiteral(){ Lng = 175.790222, Lat = -36.828611 },
-            new LatLngLiteral(){ Lng = 145.116667, Lat = -37.75 },
+            new(147.154312, -31.56391 ),
+            new(150.363181, -33.718234 ),
+            new(150.371124, -33.727111 ),
+            new(151.209834, -33.848588 ),
+            new(151.216968, -33.851702 ),
+            new(150.863657, -34.671264 ),
+            new(148.662905, -35.304724 ),
+            new(175.699196, -36.817685 ),
+            new(175.790222, -36.828611 ),
+            new(145.116667, -37.75 ),
         };
 
 
         for (int index = 0; index < 200; index++)
         {
             var dif = (index * 0.001);
-            coordinates.Add(new LatLngLiteral() { Lng = 145.116667 + dif, Lat = -37.75 + dif });
+            coordinates.Add(new LatLngLiteral(145.116667 + dif, -37.75 + dif));
         }
 
         await AddMarkersGroup(coordinates);
@@ -136,7 +132,7 @@
                 _map1.JsRuntime,
                 coordinates.ToDictionary(_ => Guid.NewGuid().ToString(), y => new AdvancedMarkerElementOptions()
                     {
-                        Position = new LatLngLiteral() { Lng = y.Lng, Lat = y.Lat },
+                        Position = y,
                         Map = _map1.InteropObject,
                         GmpDraggable = true,
                         Title = Guid.NewGuid().ToString(),
@@ -148,7 +144,7 @@
         {
             var cordDic = coordinates.ToDictionary(_ => Guid.NewGuid().ToString(), y => new AdvancedMarkerElementOptions()
                 {
-                    Position = new LatLngLiteral() { Lng = y.Lng, Lat = y.Lat },
+                    Position = y,
                     Map = _map1.InteropObject,
                     GmpDraggable = true,
                     Title = Guid.NewGuid().ToString(),
@@ -372,29 +368,29 @@
     {
         return new List<LatLngLiteral>()
         {
-            new() { Lng = 147.154312, Lat = -31.56391},
-            new() { Lng = 150.363181, Lat = -33.718234},
-            new() { Lng = 150.371124, Lat = -33.727111},
-            new() { Lng = 151.209834, Lat = -33.848588},
-            new() { Lng = 151.216968, Lat = -33.851702},
-            new() { Lng = 150.863657, Lat = -34.671264},
-            new() { Lng = 148.662905, Lat = -35.304724},
-            new() { Lng = 175.699196, Lat = -36.817685},
-            new() { Lng = 175.790222, Lat = -36.828611},
-            new() { Lng = 145.116667, Lat = -37.75},
-            new() { Lng = 145.128708, Lat = -37.759859},
-            new() { Lng = 145.133858, Lat = -37.765015},
-            new() { Lng = 145.143299, Lat = -37.770104},
-            new() { Lng = 145.145187, Lat = -37.7737},
-            new() { Lng = 145.137978, Lat = -37.774785},
-            new() { Lng = 144.968119, Lat = -37.819616},
-            new() { Lng = 144.695692, Lat = -38.330766},
-            new() { Lng = 175.053218, Lat = -39.927193},
-            new() { Lng = 174.865694, Lat = -41.330162},
-            new() { Lng = 147.439506, Lat = -42.734358},
-            new() { Lng = 147.501315, Lat = -42.734358},
-            new() { Lng = 147.438, Lat = -42.735258},
-            new() { Lng = 170.463352, Lat = -43.999792},
+            new(147.154312, -31.56391),
+            new(150.363181, -33.718234),
+            new(150.371124, -33.727111),
+            new(151.209834, -33.848588),
+            new(151.216968, -33.851702),
+            new(150.863657, -34.671264),
+            new(148.662905, -35.304724),
+            new(175.699196, -36.817685),
+            new(175.790222, -36.828611),
+            new(145.116667, -37.75),
+            new(145.128708, -37.759859),
+            new(145.133858, -37.765015),
+            new(145.143299, -37.770104),
+            new(145.145187, -37.7737),
+            new(145.137978, -37.774785),
+            new(144.968119, -37.819616),
+            new(144.695692, -38.330766),
+            new(175.053218, -39.927193),
+            new(174.865694, -41.330162),
+            new(147.439506, -42.734358),
+            new(147.501315, -42.734358),
+            new(147.438, -42.735258),
+            new(170.463352, -43.999792),
         };
     }
 }

--- a/ClientSideDemo/Pages/MapEvents.razor
+++ b/ClientSideDemo/Pages/MapEvents.razor
@@ -33,11 +33,7 @@
         _mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Center = new LatLngLiteral( 13.505892,100.8162),
             MapTypeId = MapTypeId.Roadmap
         };
     }

--- a/ClientSideDemo/Pages/MapInfoWindow.razor
+++ b/ClientSideDemo/Pages/MapInfoWindow.razor
@@ -19,12 +19,8 @@
     {
         _mapOptions = new MapOptions()
         {
-            Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Zoom = 13,          
+            Center = new LatLngLiteral( 13.505892,100.8162),
             MapTypeId = MapTypeId.Roadmap
         };
     }
@@ -42,12 +38,7 @@
 
         var infoWindow = await InfoWindow.CreateAsync(_map1.JsRuntime, new InfoWindowOptions()
         {
-            Position = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
-            //Content = "Test"
+            Position = new LatLngLiteral( 13.505892,100.8162),
         });
 
         var infoWindowContent = $"Test {_markerCount}";

--- a/ClientSideDemo/Pages/MapMarker.razor
+++ b/ClientSideDemo/Pages/MapMarker.razor
@@ -39,11 +39,7 @@
         _mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Center = new LatLngLiteral( 13.505892,100.8162),
             MapTypeId = MapTypeId.Roadmap
         };
     }
@@ -163,29 +159,29 @@
     {
         var coordinates = new List<LatLngLiteral>()
             {
-                new LatLngLiteral() { Lng = 147.154312, Lat = -31.56391 },
-                new LatLngLiteral() { Lng = 150.363181, Lat = -33.718234 },
-                new LatLngLiteral() { Lng = 150.371124,Lat =  -33.727111 },
-                new LatLngLiteral() { Lng = 151.209834,Lat =  -33.848588 },
-                new LatLngLiteral() { Lng = 151.216968,Lat =  -33.851702 },
-                new LatLngLiteral() { Lng = 150.863657,Lat =  -34.671264 },
-                new LatLngLiteral() { Lng = 148.662905,Lat =  -35.304724 },
-                new LatLngLiteral() { Lng = 175.699196,Lat =  -36.817685 },
-                new LatLngLiteral() { Lng = 175.790222,Lat =  -36.828611 },
-                new LatLngLiteral() { Lng = 145.116667,Lat =  -37.75 },
-                new LatLngLiteral() { Lng = 145.128708,Lat =  -37.759859 },
-                new LatLngLiteral() { Lng = 145.133858,Lat =  -37.765015 },
-                new LatLngLiteral() { Lng = 145.143299,Lat =  -37.770104 },
-                new LatLngLiteral() { Lng = 145.145187,Lat =  -37.7737 },
-                new LatLngLiteral() { Lng = 145.137978,Lat =  -37.774785 },
-                new LatLngLiteral() { Lng = 144.968119,Lat =  -37.819616 },
-                new LatLngLiteral() { Lng = 144.695692,Lat =  -38.330766 },
-                new LatLngLiteral() { Lng = 175.053218,Lat =  -39.927193 },
-                new LatLngLiteral() { Lng = 174.865694,Lat =  -41.330162 },
-                new LatLngLiteral() { Lng = 147.439506,Lat =  -42.734358 },
-                new LatLngLiteral() { Lng = 147.501315,Lat =  -42.734358 },
-                new LatLngLiteral() { Lng = 147.438,Lat =  -42.735258 },
-                new LatLngLiteral() { Lng = 170.463352,Lat =  -43.999792 },
+                new(147.154312, -31.56391 ),
+                new(150.363181, -33.718234 ),
+                new(150.371124,  -33.727111 ),
+                new(151.209834,  -33.848588 ),
+                new(151.216968,  -33.851702 ),
+                new(150.863657,  -34.671264 ),
+                new(148.662905,  -35.304724 ),
+                new(175.699196,  -36.817685 ),
+                new(175.790222,  -36.828611 ),
+                new(145.116667,  -37.75 ),
+                new(145.128708,  -37.759859 ),
+                new(145.133858,  -37.765015 ),
+                new(145.143299,  -37.770104 ),
+                new(145.145187,  -37.7737 ),
+                new(145.137978,  -37.774785 ),
+                new(144.968119,  -37.819616 ),
+                new(144.695692,  -38.330766 ),
+                new(175.053218,  -39.927193 ),
+                new(174.865694,  -41.330162 ),
+                new(147.439506,  -42.734358 ),
+                new(147.501315,  -42.734358 ),
+                new(147.438,  -42.735258 ),
+                new(170.463352,  -43.999792 ),
             };
 
         var markers = await GetMarkers(coordinates, _map1.InteropObject);
@@ -198,7 +194,7 @@
         
 
 
-        LatLngBoundsLiteral? boundsLiteral = new LatLngBoundsLiteral(new LatLngLiteral() { Lat = coordinates.First().Lat, Lng = coordinates.First().Lng });
+        LatLngBoundsLiteral? boundsLiteral = new LatLngBoundsLiteral(coordinates.First());
         foreach (var literal in coordinates)
         {
             LatLngBoundsLiteral.CreateOrExtend(ref boundsLiteral, literal);

--- a/ClientSideDemo/Pages/MapPolyline.razor
+++ b/ClientSideDemo/Pages/MapPolyline.razor
@@ -36,11 +36,7 @@
         _mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Center = new LatLngLiteral( 13.505892,100.8162),
             MapTypeId = MapTypeId.Roadmap
         };
     }

--- a/ClientSideDemo/Pages/MapRoutes.razor
+++ b/ClientSideDemo/Pages/MapRoutes.razor
@@ -25,11 +25,7 @@
         _mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 40.603629,
-                Lng = -75.472518
-            },
+            Center = new LatLngLiteral( 13.505892,100.8162),
             MapTypeId = MapTypeId.Roadmap
         };
     }

--- a/ClientSideDemo/Pages/Maps.razor
+++ b/ClientSideDemo/Pages/Maps.razor
@@ -33,11 +33,7 @@
             var mapOptions1 = new MapOptions()
             {
                 Zoom = 13,
-                Center = new LatLngLiteral()
-                {
-                    Lat = 13.505892,
-                    Lng = 100.8162
-                },
+                Center = new LatLngLiteral( 13.505892,100.8162),
                 MapTypeId = MapTypeId.Roadmap,
                 ApiLoadOptions = MapApiLoadOptions,
             };
@@ -52,11 +48,7 @@
             var mapOptions2 = new MapOptions()
             {
                 Zoom = 18,
-                Center = new LatLngLiteral()
-                {
-                    Lat = 45.518,
-                    Lng = -122.672
-                },
+                Center = new LatLngLiteral(45.518, -122.672),
                 MapTypeId = MapTypeId.Satellite,
                 Heading = 90,
                 Tilt = 45,

--- a/GoogleMapsComponents/GoogleMapsComponents.csproj
+++ b/GoogleMapsComponents/GoogleMapsComponents.csproj
@@ -15,7 +15,7 @@
 		<RazorLangVersion>3.0</RazorLangVersion>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>BlazorGoogleMaps</PackageId>
-		<Version>4.12.2</Version>
+		<Version>4.13.0</Version>
 		<Authors>Rungwiroon</Authors>
 		<Company>QueueStack Solution</Company>
 		<Product>BlazorGoogleMaps</Product>

--- a/GoogleMapsComponents/Maps/Coordinates/LatLngBoundsLiteral.cs
+++ b/GoogleMapsComponents/Maps/Coordinates/LatLngBoundsLiteral.cs
@@ -26,9 +26,9 @@ public class LatLngBoundsLiteral
         West = latLng1.Lng;
         South = latLng1.Lat;
         North = latLng1.Lat;
-        if (latLng2 != null)
+        if (latLng2.HasValue)
         {
-            Extend(latLng2);
+            Extend(latLng2.Value);
         }
     }
 
@@ -127,6 +127,7 @@ public class LatLngBoundsLiteral
         return (West == East || South == North);
     }
 
+    /// <inheritdoc />
     public override string ToString()
     {
         return $"{North} {East} {South} {West}";

--- a/GoogleMapsComponents/Maps/Coordinates/LatLngLiteral.cs
+++ b/GoogleMapsComponents/Maps/Coordinates/LatLngLiteral.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using GoogleMapsComponents.Serialization;
+using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
 
 namespace GoogleMapsComponents.Maps;
@@ -9,35 +11,78 @@ namespace GoogleMapsComponents.Maps;
 /// These are converted to LatLng objects when the Maps API encounters them.
 /// </summary>
 [DebuggerDisplay("{Lat}, {Lng}")]
-public class LatLngLiteral
+[StructLayout(LayoutKind.Explicit, Size = sizeof(double) * 2)]
+[JsonConverter(typeof(LatLngLiteralConverter))]
+public readonly struct LatLngLiteral : IEquatable<LatLngLiteral>
 {
     /// <summary>
     /// Latitude in degrees. Values will be clamped to the range [-90, 90]. 
     /// This means that if the value specified is less than -90, it will be set to -90. 
     /// And if the value is greater than 90, it will be set to 90.
     /// </summary>
-    [JsonPropertyName("lat")]
-    public double Lat { get; set; }
+    [FieldOffset(0)]
+    public readonly double Lat;
 
     /// <summary>
     /// Longitude in degrees. Values outside the range [-180, 180] will be wrapped so that they fall within the range. 
     /// For example, a value of -190 will be converted to 170. A value of 190 will be converted to -170. 
     /// This reflects the fact that longitudes wrap around the globe.
     /// </summary>
-    [JsonPropertyName("lng")]
-    public double Lng { get; set; }
-
-    public LatLngLiteral()
-    {
-    }
-
+    [FieldOffset(sizeof(double))]
+    public readonly double Lng; 
+    
+    /// <summary>
+    /// Default constructor
+    /// </summary>
+    /// <param name="lat">Latitude value</param>
+    /// <param name="lng">Longitude value</param>
     public LatLngLiteral(double lat, double lng)
     {
         Lat = lat;
         Lng = lng;
     }
 
-    public LatLngLiteral(decimal lat, decimal lng) : this(Convert.ToDouble(lat), Convert.ToDouble(lng))
+    #region Methods
+
+    /// <inheritdoc />
+    public bool Equals(LatLngLiteral other)
     {
+        return Lat.Equals(other.Lat) && Lng.Equals(other.Lng);
     }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is LatLngLiteral other && Equals(other);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Lat, Lng);
+    }
+
+    /// <summary>
+    /// Checks if two <see cref="LatLngLiteral"/> instances are equal
+    /// </summary>
+    /// <param name="left">Left hand value</param>
+    /// <param name="right">Right hand value</param>
+    /// <returns><see langword="true" /> if both items are equal.</returns>
+    public static bool operator ==(LatLngLiteral left, LatLngLiteral right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Checks if two <see cref="LatLngLiteral"/> instances are unequal
+    /// </summary>
+    /// <param name="left">Left hand value</param>
+    /// <param name="right">Right hand value</param>
+    /// <returns><see langword="true" /> if both items are unequal.</returns>
+    public static bool operator !=(LatLngLiteral left, LatLngLiteral right)
+    {
+        return !left.Equals(right);
+    }
+
+    #endregion
 }

--- a/GoogleMapsComponents/Serialization/LatLngLiteralConverter.cs
+++ b/GoogleMapsComponents/Serialization/LatLngLiteralConverter.cs
@@ -1,0 +1,60 @@
+﻿using GoogleMapsComponents.Maps;
+using System; 
+using System.Text.Json;
+using System.Text.Json.Serialization; 
+
+namespace GoogleMapsComponents.Serialization;
+
+/// <summary>
+/// JSON Converter for <see cref="LatLngLiteral"/> objects.
+/// </summary>
+internal sealed class LatLngLiteralConverter : JsonConverter<LatLngLiteral>
+{
+    /// <inheritdoc />
+    public override LatLngLiteral Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected start of object.");
+        }
+
+        if (!reader.Read())
+        {
+            throw new JsonException("Expected property name.");
+        }
+
+        if (!reader.Read() || reader.TokenType != JsonTokenType.Number)
+        {
+            throw new JsonException("Expected latitude value");
+        }
+        
+        var lat = reader.GetDouble();
+
+        if (!reader.Read())
+        {
+            throw new JsonException("Expected property name.");
+        }
+
+        if (!reader.Read() || reader.TokenType != JsonTokenType.Number)
+        {
+            throw new JsonException("Expected latitude value");
+        }
+        var lon = reader.GetDouble();
+
+        if (!reader.Read() || reader.TokenType != JsonTokenType.EndObject)
+        {
+            throw new JsonException("Expected end of object.");
+        }
+        
+        return new LatLngLiteral(lat, lon);
+    }
+
+    // <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, LatLngLiteral value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteNumber("lat", value.Lat);
+        writer.WriteNumber("lng", value.Lng);
+        writer.WriteEndObject();
+    }
+}

--- a/ServerSideDemo/Pages/AdvancedMarkerComponent.razor
+++ b/ServerSideDemo/Pages/AdvancedMarkerComponent.razor
@@ -52,11 +52,7 @@
     private readonly MapOptions _mapOptions = new MapOptions()
     {
         Zoom = 13,
-        Center = new LatLngLiteral()
-        {
-            Lat = 13.505892,
-            Lng = 100.8162
-        },
+        Center = new LatLngLiteral( 13.505892,100.8162),
         IsFractionalZoomEnabled = false,
         HeadingInteractionEnabled = true,
         CameraControl = true,

--- a/ServerSideDemo/Pages/DisposeMapCircleListPage.razor.cs
+++ b/ServerSideDemo/Pages/DisposeMapCircleListPage.razor.cs
@@ -27,11 +27,7 @@ public partial class DisposeMapCircleListPage : ComponentBase, IDisposable, IAsy
         _mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 48.994249,
-                Lng = 12.190451
-            },
+            Center = new LatLngLiteral( 48.994249,12.190451),
             MapTypeId = MapTypeId.Roadmap
         };
     }
@@ -73,11 +69,10 @@ public partial class DisposeMapCircleListPage : ComponentBase, IDisposable, IAsy
             var circleOptions = new CircleOptions
             {
                 Map = _map1.InteropObject,
-                Center = new LatLngLiteral
-                {
-                    Lat = bounds.South + rnd.NextDouble() * (bounds.North - bounds.South),
-                    Lng = bounds.West + rnd.NextDouble() * (bounds.East - bounds.West)
-                },
+                Center = new LatLngLiteral(
+                    bounds.South + rnd.NextDouble() * (bounds.North - bounds.South),
+                    bounds.West + rnd.NextDouble() * (bounds.East - bounds.West)
+                ),
                 Radius = 2,
                 StrokeColor = color,
                 StrokeOpacity = 0.60f,

--- a/ServerSideDemo/Pages/DrawingManagerPage.razor.cs
+++ b/ServerSideDemo/Pages/DrawingManagerPage.razor.cs
@@ -23,11 +23,7 @@ public partial class DrawingManagerPage
         _mapOptions = new MapOptions()
         {
             Zoom = 16,
-            Center = new LatLngLiteral()
-            {
-                Lat = -31.74230723298461,
-                Lng = -60.494505564961386
-            },
+            Center = new LatLngLiteral( -31.74230723298461,-60.494505564961386),
             MapTypeId = MapTypeId.Roadmap,
             ZoomControl = true,
             DisableDefaultUI = true

--- a/ServerSideDemo/Pages/GMap.razor.cs
+++ b/ServerSideDemo/Pages/GMap.razor.cs
@@ -94,8 +94,16 @@ public partial class GMap
 #if DEBUG
         Console.WriteLine("GMap Initialized:");
         Console.WriteLine($"\t Height: {Height}");
-        Console.WriteLine($"\t Zoom: {Options.Zoom}");
-        Console.WriteLine($"\t Center: ({Options.Center.Lat}, {Options.Center.Lng})");
+        if (Options != null)
+        {
+            Console.WriteLine($"\t Options: {Options}");
+
+            Console.WriteLine($"\t Zoom: {Options.Zoom}");
+            if (Options.Center.HasValue)
+            {
+                Console.WriteLine($"\t Center: ({Options.Center.Value.Lat}, {Options.Center.Value.Lng})");
+            }
+        }
 #endif
         if (MeMarker != null)
         {

--- a/ServerSideDemo/Pages/KmlExample.razor
+++ b/ServerSideDemo/Pages/KmlExample.razor
@@ -18,11 +18,7 @@
     private readonly MapOptions _mapOptions = new MapOptions()
     {
         Zoom = 2,
-        Center = new LatLngLiteral()
-        {
-            Lat = -19.257753,
-            Lng = 146.823688
-        },
+        Center = new LatLngLiteral(-19.257753, 146.823688),
         MapTypeId = MapTypeId.Terrain
     };
 

--- a/ServerSideDemo/Pages/MapAdvancedMarkerViewPage.razor
+++ b/ServerSideDemo/Pages/MapAdvancedMarkerViewPage.razor
@@ -34,11 +34,7 @@
     private readonly MapOptions _mapOptions = new MapOptions()
     {
         Zoom = 13,
-        Center = new LatLngLiteral()
-        {
-            Lat = 13.505892,
-            Lng = 100.8162
-        },
+        Center = new LatLngLiteral( 13.505892,100.8162),
         IsFractionalZoomEnabled = false,
         HeadingInteractionEnabled = false,
         CameraControl = true,
@@ -94,19 +90,19 @@
     {
         var coordinates = new List<LatLngLiteral>()
         {
-            new LatLngLiteral(){ Lng = 145.128708, Lat = -37.759859 },
-            new LatLngLiteral(){ Lng = 145.133858, Lat = -37.765015 },
-            new LatLngLiteral(){ Lng = 145.143299, Lat = -37.770104 },
-            new LatLngLiteral(){ Lng = 145.145187, Lat = -37.7737 },
-            new LatLngLiteral(){ Lng = 145.137978, Lat = -37.774785 },
-            new LatLngLiteral(){ Lng = 144.968119, Lat = -37.819616 },
-            new LatLngLiteral(){ Lng = 144.695692, Lat = -38.330766 },
-            new LatLngLiteral(){ Lng = 175.053218, Lat = -39.927193 },
-            new LatLngLiteral(){ Lng = 174.865694, Lat = -41.330162 },
-            new LatLngLiteral(){ Lng = 147.439506, Lat = -42.734358 },
-            new LatLngLiteral(){ Lng = 147.501315, Lat = -42.734358 },
-            new LatLngLiteral(){ Lng = 147.438, Lat = -42.735258 },
-            new LatLngLiteral(){ Lng = 170.463352, Lat = -43.999792 },
+            new(145.128708, -37.759859 ),
+            new(145.133858, -37.765015 ),
+            new(145.143299, -37.770104 ),
+            new(145.145187, -37.7737 ),
+            new(145.137978, -37.774785 ),
+            new(144.968119, -37.819616 ),
+            new(144.695692, -38.330766 ),
+            new(175.053218, -39.927193 ),
+            new(174.865694, -41.330162 ),
+            new(147.439506, -42.734358 ),
+            new(147.501315, -42.734358 ),
+            new(147.438, -42.735258 ),
+            new(170.463352, -43.999792 ),
         };
         await AddMarkersGroup(coordinates);
     }
@@ -115,23 +111,23 @@
     {
         var coordinates = new List<LatLngLiteral>()
         {
-            new LatLngLiteral(){ Lng = 147.154312, Lat = -31.56391 },
-            new LatLngLiteral(){ Lng = 150.363181, Lat = -33.718234 },
-            new LatLngLiteral(){ Lng = 150.371124, Lat = -33.727111 },
-            new LatLngLiteral(){ Lng = 151.209834, Lat = -33.848588 },
-            new LatLngLiteral(){ Lng = 151.216968, Lat = -33.851702 },
-            new LatLngLiteral(){ Lng = 150.863657, Lat = -34.671264 },
-            new LatLngLiteral(){ Lng = 148.662905, Lat = -35.304724 },
-            new LatLngLiteral(){ Lng = 175.699196, Lat = -36.817685 },
-            new LatLngLiteral(){ Lng = 175.790222, Lat = -36.828611 },
-            new LatLngLiteral(){ Lng = 145.116667, Lat = -37.75 },
+            new(147.154312, -31.56391 ),
+            new(150.363181, -33.718234 ),
+            new(150.371124, -33.727111 ),
+            new(151.209834, -33.848588 ),
+            new(151.216968, -33.851702 ),
+            new(150.863657, -34.671264 ),
+            new(148.662905, -35.304724 ),
+            new(175.699196, -36.817685 ),
+            new(175.790222, -36.828611 ),
+            new(145.116667, -37.75 ),
         };
 
 
         for (int index = 0; index < 200; index++)
         {
             var dif = (index * 0.001);
-            coordinates.Add(new LatLngLiteral() { Lng = 145.116667 + dif, Lat = -37.75 + dif });
+            coordinates.Add(new LatLngLiteral(145.116667 + dif, -37.75 + dif));
         }
 
         await AddMarkersGroup(coordinates);
@@ -147,7 +143,7 @@
                 _map1.JsRuntime,
                 coordinates.ToDictionary(_ => Guid.NewGuid().ToString(), y => new AdvancedMarkerElementOptions()
                     {
-                        Position = new LatLngLiteral() { Lng = y.Lng, Lat = y.Lat },
+                        Position = y,
                         Map = _map1.InteropObject,
                         GmpDraggable = true,
                         Title = Guid.NewGuid().ToString(),
@@ -159,7 +155,7 @@
         {
             var cordDic = coordinates.ToDictionary(_ => Guid.NewGuid().ToString(), y => new AdvancedMarkerElementOptions()
                 {
-                    Position = new LatLngLiteral() { Lng = y.Lng, Lat = y.Lat },
+                    Position = y,
                     Map = _map1.InteropObject,
                     GmpDraggable = true,
                     Title = Guid.NewGuid().ToString(),
@@ -390,29 +386,29 @@
     {
         return new List<LatLngLiteral>()
         {
-            new() { Lng = 147.154312, Lat = -31.56391},
-            new() { Lng = 150.363181, Lat = -33.718234},
-            new() { Lng = 150.371124, Lat = -33.727111},
-            new() { Lng = 151.209834, Lat = -33.848588},
-            new() { Lng = 151.216968, Lat = -33.851702},
-            new() { Lng = 150.863657, Lat = -34.671264},
-            new() { Lng = 148.662905, Lat = -35.304724},
-            new() { Lng = 175.699196, Lat = -36.817685},
-            new() { Lng = 175.790222, Lat = -36.828611},
-            new() { Lng = 145.116667, Lat = -37.75},
-            new() { Lng = 145.128708, Lat = -37.759859},
-            new() { Lng = 145.133858, Lat = -37.765015},
-            new() { Lng = 145.143299, Lat = -37.770104},
-            new() { Lng = 145.145187, Lat = -37.7737},
-            new() { Lng = 145.137978, Lat = -37.774785},
-            new() { Lng = 144.968119, Lat = -37.819616},
-            new() { Lng = 144.695692, Lat = -38.330766},
-            new() { Lng = 175.053218, Lat = -39.927193},
-            new() { Lng = 174.865694, Lat = -41.330162},
-            new() { Lng = 147.439506, Lat = -42.734358},
-            new() { Lng = 147.501315, Lat = -42.734358},
-            new() { Lng = 147.438, Lat = -42.735258},
-            new() { Lng = 170.463352, Lat = -43.999792},
+            new(147.154312, -31.56391),
+            new(150.363181, -33.718234),
+            new(150.371124, -33.727111),
+            new(151.209834, -33.848588),
+            new(151.216968, -33.851702),
+            new(150.863657, -34.671264),
+            new(148.662905, -35.304724),
+            new(175.699196, -36.817685),
+            new(175.790222, -36.828611),
+            new(145.116667, -37.75),
+            new(145.128708, -37.759859),
+            new(145.133858, -37.765015),
+            new(145.143299, -37.770104),
+            new(145.145187, -37.7737),
+            new(145.137978, -37.774785),
+            new(144.968119, -37.819616),
+            new(144.695692, -38.330766),
+            new(175.053218, -39.927193),
+            new(174.865694, -41.330162),
+            new(147.439506, -42.734358),
+            new(147.501315, -42.734358),
+            new(147.438, -42.735258),
+            new(170.463352, -43.999792),
         };
     }
 

--- a/ServerSideDemo/Pages/MapAutocomplete.razor
+++ b/ServerSideDemo/Pages/MapAutocomplete.razor
@@ -38,11 +38,7 @@
         this.mapOptions = new MapOptions
         {
             Zoom = 13,
-            Center = new LatLngLiteral
-            {
-                Lat = -33.8688,
-                Lng = 151.2195
-            },
+            Center = new LatLngLiteral(-33.8688,151.2195),
             MapTypeId = MapTypeId.Roadmap
         };
     }
@@ -67,14 +63,14 @@
             {
                 this.message = "No results available for " + place?.Name;
             }
-            else if (place.Geometry.Location != null)
+            else if (place.Geometry.Location.HasValue)
             {
-                await this.map1.InteropObject.SetCenter(place.Geometry.Location);
+                await this.map1.InteropObject.SetCenter(place.Geometry.Location.Value);
                 await this.map1.InteropObject.SetZoom(13);
 
                 var marker = await Marker.CreateAsync(this.map1.JsRuntime, new MarkerOptions
                 {
-                    Position = place.Geometry.Location,
+                    Position = place.Geometry.Location.Value,
                     Map = this.map1.InteropObject,
                     Title = place.Name
                 });

--- a/ServerSideDemo/Pages/MapCircleListPage.razor.cs
+++ b/ServerSideDemo/Pages/MapCircleListPage.razor.cs
@@ -25,11 +25,7 @@ public partial class MapCircleListPage : ComponentBase
         _mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 48.994249,
-                Lng = 12.190451
-            },
+            Center = new LatLngLiteral(48.994249,12.190451),
             MapTypeId = MapTypeId.Roadmap
         };
     }
@@ -85,11 +81,10 @@ public partial class MapCircleListPage : ComponentBase
             var circleOptions = new CircleOptions
             {
                 Map = _map.InteropObject,
-                Center = new LatLngLiteral
-                {
-                    Lat = bounds.South + rnd.NextDouble() * (bounds.North - bounds.South),
-                    Lng = bounds.West + rnd.NextDouble() * (bounds.East - bounds.West)
-                },
+                Center = new LatLngLiteral(
+                    bounds.South + rnd.NextDouble() * (bounds.North - bounds.South),
+                    bounds.West + rnd.NextDouble() * (bounds.East - bounds.West)
+                ),
                 Radius = (rnd.NextDouble() + 0.2) / 1.2 * maxRadius,
                 StrokeColor = color,
                 StrokeOpacity = 0.60f,

--- a/ServerSideDemo/Pages/MapDataPage.razor
+++ b/ServerSideDemo/Pages/MapDataPage.razor
@@ -29,11 +29,7 @@
         _mapOptions = new MapOptions
             {
                 Zoom = 13,
-                Center = new LatLngLiteral
-                {
-                    Lat = -33.8688,
-                    Lng = 151.2195
-                },
+                Center = new LatLngLiteral(-33.8688, 151.2195),
                 MapTypeId = MapTypeId.Roadmap
             };
     }

--- a/ServerSideDemo/Pages/MapEvents.razor
+++ b/ServerSideDemo/Pages/MapEvents.razor
@@ -35,11 +35,7 @@
         _mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Center = new LatLngLiteral(13.505892, 100.8162),
             MapTypeId = MapTypeId.Roadmap
         };
     }

--- a/ServerSideDemo/Pages/MapGroundOverlayPage.razor.cs
+++ b/ServerSideDemo/Pages/MapGroundOverlayPage.razor.cs
@@ -20,11 +20,7 @@ public partial class MapGroundOverlayPage
         _mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 40.719051,
-                Lng = -74.166269
-            },
+            Center = new LatLngLiteral(40.719051,-74.166269),
             MapTypeId = MapTypeId.Roadmap
         };
     }

--- a/ServerSideDemo/Pages/MapHeatMapPage.razor.cs
+++ b/ServerSideDemo/Pages/MapHeatMapPage.razor.cs
@@ -17,11 +17,7 @@ public partial class MapHeatMapPage
         mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Center = new LatLngLiteral(  13.505892, 100.8162),
             MapTypeId = MapTypeId.Roadmap
         };
     }
@@ -35,20 +31,9 @@ public partial class MapHeatMapPage
             Radius = 10,
         });
 
-        var heatPoints = new[] {
-            new LatLngLiteral{
-                Lat = 13.505892,
-                Lng = 100.8162,
-            },
-            new LatLngLiteral{
-                Lat = 13.506892,
-                Lng = 100.8162,
-            },
-        };
-
         var hwp = new List<WeightedLocation>();
-        hwp.Add(new WeightedLocation { Location = new LatLngLiteral { Lat = 13.505892, Lng = 100.8142 }, Weight = 3 });
-        hwp.Add(new WeightedLocation { Location = new LatLngLiteral { Lat = 13.506892, Lng = 100.8132 }, Weight = 5 });
+        hwp.Add(new WeightedLocation { Location = new LatLngLiteral (13.505892, 100.8142), Weight = 3 });
+        hwp.Add(new WeightedLocation { Location = new LatLngLiteral (13.506892, 100.8132), Weight = 5 });
 
         await heatMap.SetData(hwp);
 

--- a/ServerSideDemo/Pages/MapImageOverlay.razor
+++ b/ServerSideDemo/Pages/MapImageOverlay.razor
@@ -47,11 +47,7 @@ Overlay Opacity:
         mapOptions = new MapOptions()
             {
                 Zoom = 13,
-                Center = new LatLngLiteral()
-                {
-                    Lat = 13.505892,
-                    Lng = 100.8162
-                },
+                Center = new LatLngLiteral(13.505892, 100.8162),
                 MapTypeId = MapTypeId.Roadmap
             };
     }

--- a/ServerSideDemo/Pages/MapInfoWindow.razor
+++ b/ServerSideDemo/Pages/MapInfoWindow.razor
@@ -20,11 +20,7 @@
         mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Center = new LatLngLiteral(13.505892, 100.8162),
             MapTypeId = MapTypeId.Roadmap
         };
     }
@@ -60,13 +56,7 @@
 
         var infoWindow = await InfoWindow.CreateAsync(map1.JsRuntime, new InfoWindowOptions()
         {
-            Position = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
-
-            //Content = infoWindowContent
+            Position = new LatLngLiteral( 13.505892,100.8162)
         });
 
 

--- a/ServerSideDemo/Pages/MapLayerPage.razor
+++ b/ServerSideDemo/Pages/MapLayerPage.razor
@@ -25,11 +25,7 @@
         _mapOptions = new MapOptions
         {
             Zoom = 13,
-            Center = new LatLngLiteral
-            {
-                Lat = -33.8688,
-                Lng = 151.2195
-            },
+            Center = new LatLngLiteral(-33.8688, 151.2195),
             MapTypeId = MapTypeId.Roadmap
         };
     }

--- a/ServerSideDemo/Pages/MapLegendPage.razor.cs
+++ b/ServerSideDemo/Pages/MapLegendPage.razor.cs
@@ -26,11 +26,7 @@ public partial class MapLegendPage
             {
                 Position = ControlPosition.BottomCenter
             },
-            Center = new LatLngLiteral
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Center = new LatLngLiteral(13.505892,100.8162),
             MapTypeId = MapTypeId.Terrain,
             MapTypeControlOptions = new MapTypeControlOptions
             {

--- a/ServerSideDemo/Pages/MapMapControlEvents.razor
+++ b/ServerSideDemo/Pages/MapMapControlEvents.razor
@@ -24,11 +24,7 @@
         mapOptions = new MapOptions()
             {
                 Zoom = 13,
-                Center = new LatLngLiteral()
-                {
-                    Lat = 13.505892,
-                    Lng = 100.8162
-                },
+                Center = new LatLngLiteral(13.505892, 100.8162),
                 MapTypeId = MapTypeId.Roadmap
             };
     }

--- a/ServerSideDemo/Pages/MapMarker.razor.cs
+++ b/ServerSideDemo/Pages/MapMarker.razor.cs
@@ -24,7 +24,7 @@ public partial class MapMarker
 
     private LatLngBounds _bounds;
     private MarkerClustering? _markerClustering;
-    public int ZIndex { get; set; } = 0;
+    public int ZIndex { get; set; }
 
     [Inject]
     public IJSRuntime JsObjectRef { get; set; }
@@ -34,11 +34,7 @@ public partial class MapMarker
         _mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Center = new LatLngLiteral(13.505892, 100.8162), 
             MapTypeId = MapTypeId.Roadmap,
             MapId = "3a3b33f0edd6ed2a"
         };
@@ -78,7 +74,7 @@ public partial class MapMarker
         }
         await _markerClustering.AddMarkers(markers);
 
-        var boundsLiteral = new LatLngBoundsLiteral(new LatLngLiteral() { Lat = coordinates.First().Lat, Lng = coordinates.First().Lng });
+        var boundsLiteral = new LatLngBoundsLiteral(coordinates.First());
         foreach (var literal in coordinates)
         {
             LatLngBoundsLiteral.CreateOrExtend(ref boundsLiteral, literal);
@@ -156,29 +152,29 @@ public partial class MapMarker
     {
         return new List<LatLngLiteral>()
         {
-            new() { Lng = 147.154312, Lat = -31.56391},
-            new() { Lng = 150.363181, Lat = -33.718234},
-            new() { Lng = 150.371124, Lat = -33.727111},
-            new() { Lng = 151.209834, Lat = -33.848588},
-            new() { Lng = 151.216968, Lat = -33.851702},
-            new() { Lng = 150.863657, Lat = -34.671264},
-            new() { Lng = 148.662905, Lat = -35.304724},
-            new() { Lng = 175.699196, Lat = -36.817685},
-            new() { Lng = 175.790222, Lat = -36.828611},
-            new() { Lng = 145.116667, Lat = -37.75},
-            new() { Lng = 145.128708, Lat = -37.759859},
-            new() { Lng = 145.133858, Lat = -37.765015},
-            new() { Lng = 145.143299, Lat = -37.770104},
-            new() { Lng = 145.145187, Lat = -37.7737},
-            new() { Lng = 145.137978, Lat = -37.774785},
-            new() { Lng = 144.968119, Lat = -37.819616},
-            new() { Lng = 144.695692, Lat = -38.330766},
-            new() { Lng = 175.053218, Lat = -39.927193},
-            new() { Lng = 174.865694, Lat = -41.330162},
-            new() { Lng = 147.439506, Lat = -42.734358},
-            new() { Lng = 147.501315, Lat = -42.734358},
-            new() { Lng = 147.438, Lat = -42.735258},
-            new() { Lng = 170.463352, Lat = -43.999792},
+            new(147.154312, -31.56391),
+            new(150.363181, -33.718234),
+            new(150.371124, -33.727111),
+            new(151.209834, -33.848588),
+            new(151.216968, -33.851702),
+            new(150.863657, -34.671264),
+            new(148.662905, -35.304724),
+            new(175.699196, -36.817685),
+            new(175.790222, -36.828611),
+            new(145.116667, -37.75),
+            new(145.128708, -37.759859),
+            new(145.133858, -37.765015),
+            new(145.143299, -37.770104),
+            new(145.145187, -37.7737),
+            new(145.137978, -37.774785),
+            new(144.968119, -37.819616),
+            new(144.695692, -38.330766),
+            new(175.053218, -39.927193),
+            new(174.865694, -41.330162),
+            new(147.439506, -42.734358),
+            new(147.501315, -42.734358),
+            new(147.438, -42.735258),
+            new(170.463352, -43.999792),
         };
     }
 

--- a/ServerSideDemo/Pages/MapMarkerListPage.razor.cs
+++ b/ServerSideDemo/Pages/MapMarkerListPage.razor.cs
@@ -35,11 +35,7 @@ public partial class MapMarkerListPage
         mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Center = new LatLngLiteral(13.505892, 100.8162), 
             MapTypeId = MapTypeId.Roadmap
         };
     }
@@ -53,29 +49,29 @@ public partial class MapMarkerListPage
     {
         var coordinates = new List<LatLngLiteral>()
         {
-            new LatLngLiteral(){ Lng = 147.154312, Lat = -31.56391 },
-            new LatLngLiteral(){ Lng = 150.363181, Lat = -33.718234 },
-            new LatLngLiteral(){ Lng = 150.371124, Lat = -33.727111 },
-            new LatLngLiteral(){ Lng = 151.209834, Lat = -33.848588 },
-            new LatLngLiteral(){ Lng = 151.216968, Lat = -33.851702 },
-            new LatLngLiteral(){ Lng = 150.863657, Lat = -34.671264 },
-            new LatLngLiteral(){ Lng = 148.662905, Lat = -35.304724 },
-            new LatLngLiteral(){ Lng = 175.699196, Lat = -36.817685 },
-            new LatLngLiteral(){ Lng = 175.790222, Lat = -36.828611 },
-            new LatLngLiteral(){ Lng = 145.116667, Lat = -37.75 },
-            new LatLngLiteral(){ Lng = 145.128708, Lat = -37.759859 },
-            new LatLngLiteral(){ Lng = 145.133858, Lat = -37.765015 },
-            new LatLngLiteral(){ Lng = 145.143299, Lat = -37.770104 },
-            new LatLngLiteral(){ Lng = 145.145187, Lat = -37.7737 },
-            new LatLngLiteral(){ Lng = 145.137978, Lat = -37.774785 },
-            new LatLngLiteral(){ Lng = 144.968119, Lat = -37.819616 },
-            new LatLngLiteral(){ Lng = 144.695692, Lat = -38.330766 },
-            new LatLngLiteral(){ Lng = 175.053218, Lat = -39.927193 },
-            new LatLngLiteral(){ Lng = 174.865694, Lat = -41.330162 },
-            new LatLngLiteral(){ Lng = 147.439506, Lat = -42.734358 },
-            new LatLngLiteral(){ Lng = 147.501315, Lat = -42.734358 },
-            new LatLngLiteral(){ Lng = 147.438, Lat = -42.735258 },
-            new LatLngLiteral(){ Lng = 170.463352, Lat = -43.999792 },
+            new(147.154312, -31.56391 ),
+            new(150.363181, -33.718234 ),
+            new(150.371124, -33.727111 ),
+            new(151.209834, -33.848588 ),
+            new(151.216968, -33.851702 ),
+            new(150.863657, -34.671264 ),
+            new(148.662905, -35.304724 ),
+            new(175.699196, -36.817685 ),
+            new(175.790222, -36.828611 ),
+            new(145.116667, -37.75 ),
+            new(145.128708, -37.759859 ),
+            new(145.133858, -37.765015 ),
+            new(145.143299, -37.770104 ),
+            new(145.145187, -37.7737 ),
+            new(145.137978, -37.774785 ),
+            new(144.968119, -37.819616 ),
+            new(144.695692, -38.330766 ),
+            new(175.053218, -39.927193 ),
+            new(174.865694, -41.330162 ),
+            new(147.439506, -42.734358 ),
+            new(147.501315, -42.734358 ),
+            new(147.438, -42.735258 ),
+            new(170.463352, -43.999792 ),
         };
 
         var markers = await GetMarkers(coordinates, map1.InteropObject);
@@ -115,19 +111,19 @@ public partial class MapMarkerListPage
     {
         var coordinates = new List<LatLngLiteral>()
         {
-            new LatLngLiteral(){ Lng = 145.128708, Lat = -37.759859 },
-            new LatLngLiteral(){ Lng = 145.133858, Lat = -37.765015 },
-            new LatLngLiteral(){ Lng = 145.143299, Lat = -37.770104 },
-            new LatLngLiteral(){ Lng = 145.145187, Lat = -37.7737 },
-            new LatLngLiteral(){ Lng = 145.137978, Lat = -37.774785 },
-            new LatLngLiteral(){ Lng = 144.968119, Lat = -37.819616 },
-            new LatLngLiteral(){ Lng = 144.695692, Lat = -38.330766 },
-            new LatLngLiteral(){ Lng = 175.053218, Lat = -39.927193 },
-            new LatLngLiteral(){ Lng = 174.865694, Lat = -41.330162 },
-            new LatLngLiteral(){ Lng = 147.439506, Lat = -42.734358 },
-            new LatLngLiteral(){ Lng = 147.501315, Lat = -42.734358 },
-            new LatLngLiteral(){ Lng = 147.438, Lat = -42.735258 },
-            new LatLngLiteral(){ Lng = 170.463352, Lat = -43.999792 },
+            new(145.128708, -37.759859 ),
+            new(145.133858, -37.765015 ),
+            new(145.143299, -37.770104 ),
+            new(145.145187, -37.7737 ),
+            new(145.137978, -37.774785 ),
+            new(144.968119, -37.819616 ),
+            new(144.695692, -38.330766 ),
+            new(175.053218, -39.927193 ),
+            new(174.865694, -41.330162 ),
+            new(147.439506, -42.734358 ),
+            new(147.501315, -42.734358 ),
+            new(147.438, -42.735258 ),
+            new(170.463352, -43.999792 ),
         };
         await AddMarkersGroup(coordinates);
     }
@@ -136,23 +132,23 @@ public partial class MapMarkerListPage
     {
         var coordinates = new List<LatLngLiteral>()
         {
-            new LatLngLiteral(){ Lng = 147.154312, Lat = -31.56391 },
-            new LatLngLiteral(){ Lng = 150.363181, Lat = -33.718234 },
-            new LatLngLiteral(){ Lng = 150.371124, Lat = -33.727111 },
-            new LatLngLiteral(){ Lng = 151.209834, Lat = -33.848588 },
-            new LatLngLiteral(){ Lng = 151.216968, Lat = -33.851702 },
-            new LatLngLiteral(){ Lng = 150.863657, Lat = -34.671264 },
-            new LatLngLiteral(){ Lng = 148.662905, Lat = -35.304724 },
-            new LatLngLiteral(){ Lng = 175.699196, Lat = -36.817685 },
-            new LatLngLiteral(){ Lng = 175.790222, Lat = -36.828611 },
-            new LatLngLiteral(){ Lng = 145.116667, Lat = -37.75 },
+            new(147.154312, -31.56391 ),
+            new(150.363181, -33.718234 ),
+            new(150.371124, -33.727111 ),
+            new(151.209834, -33.848588 ),
+            new(151.216968, -33.851702 ),
+            new(150.863657, -34.671264 ),
+            new(148.662905, -35.304724 ),
+            new(175.699196, -36.817685 ),
+            new(175.790222, -36.828611 ),
+            new(145.116667, -37.75 ),
         };
 
 
         for (int index = 0; index < 200; index++)
         {
             var dif = (index * 0.001);
-            coordinates.Add(new LatLngLiteral() { Lng = 145.116667 + dif, Lat = -37.75 + dif });
+            coordinates.Add(new LatLngLiteral(145.116667 + dif, -37.75 + dif));
         }
 
         await AddMarkersGroup(coordinates);
@@ -168,7 +164,7 @@ public partial class MapMarkerListPage
                 map1.JsRuntime,
                 coordinates.ToDictionary(s => Guid.NewGuid().ToString(), y => new MarkerOptions()
                 {
-                    Position = new LatLngLiteral() { Lng = y.Lng, Lat = y.Lat },
+                    Position = y,
                     Map = map1.InteropObject,
                     //Icon = new Icon() { Url = s.MarkerIconPath, ScaledSize = iconSize, Anchor = iconAnchor },
                     Clickable = true,
@@ -181,7 +177,7 @@ public partial class MapMarkerListPage
         {
             var cordDic = coordinates.ToDictionary(s => Guid.NewGuid().ToString(), y => new MarkerOptions()
             {
-                Position = new LatLngLiteral() { Lng = y.Lng, Lat = y.Lat },
+                Position = y,
                 Map = map1.InteropObject,
                 //Icon = new Icon() { Url = s.MarkerIconPath, ScaledSize = iconSize, Anchor = iconAnchor },
                 Clickable = true,

--- a/ServerSideDemo/Pages/MapPolyline.razor
+++ b/ServerSideDemo/Pages/MapPolyline.razor
@@ -51,11 +51,7 @@
         _mapOptions = new MapOptions()
             {
                 Zoom = 13,
-                Center = new LatLngLiteral()
-                {
-                    Lat = 13.505892,
-                    Lng = 100.8162
-                },
+                Center = new LatLngLiteral(13.505892, 100.8162), 
                 MapTypeId = MapTypeId.Roadmap
             };
     }

--- a/ServerSideDemo/Pages/MapProjectionPage.razor
+++ b/ServerSideDemo/Pages/MapProjectionPage.razor
@@ -21,11 +21,7 @@
         mapOptions = new MapOptions()
             {
                 Zoom = 13,
-                Center = new LatLngLiteral()
-                {
-                    Lat = 13.505892,
-                    Lng = 100.8162
-                },
+                Center = new LatLngLiteral(13.505892, 100.8162), 
                 MapTypeId = MapTypeId.Roadmap
             };
     }

--- a/ServerSideDemo/Pages/MapRoutes.razor.cs
+++ b/ServerSideDemo/Pages/MapRoutes.razor.cs
@@ -21,11 +21,7 @@ public partial class MapRoutes : IAsyncDisposable
         _mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 40.603629,
-                Lng = -75.472518
-            },
+            Center = new LatLngLiteral(13.505892, 100.8162), 
             MapTypeId = MapTypeId.Roadmap
         };
     }

--- a/ServerSideDemo/Pages/MapServices.razor
+++ b/ServerSideDemo/Pages/MapServices.razor
@@ -66,11 +66,7 @@
         _mapOptions = new MapOptions
         {
             Zoom = 13,
-            Center = new LatLngLiteral
-            {
-                Lat = -33.8688,
-                Lng = 151.2195
-            },
+            Center = new LatLngLiteral(-33.8688,151.2195),
             MapTypeId = MapTypeId.Roadmap
         };
     }
@@ -229,14 +225,14 @@
         {
             _message = "No results available for " + place?.Name;
         }
-        else if (place.Geometry.Location != null)
+        else if (place.Geometry.Location.HasValue)
         {
-            await _map1.InteropObject.SetCenter(place.Geometry.Location);
+            await _map1.InteropObject.SetCenter(place.Geometry.Location.Value);
             await _map1.InteropObject.SetZoom(13);
 
             var marker = await Marker.CreateAsync(_map1.JsRuntime, new MarkerOptions
             {
-                Position = place.Geometry.Location,
+                Position = place.Geometry.Location.Value,
                 Map = _map1.InteropObject,
                 Title = place.FormattedAddress
             });

--- a/ServerSideDemo/Pages/MapStylePage.razor.cs
+++ b/ServerSideDemo/Pages/MapStylePage.razor.cs
@@ -13,11 +13,7 @@ public partial class MapStylePage
         _mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Center = new LatLngLiteral(13.505892, 100.8162), 
             MapTypeId = MapTypeId.Roadmap,
             Styles = MapStyle()
         };

--- a/ServerSideDemo/Pages/Maps.razor
+++ b/ServerSideDemo/Pages/Maps.razor
@@ -33,11 +33,7 @@
             var mapOptions1 = new MapOptions()
                 {
                     Zoom = 13,
-                    Center = new LatLngLiteral()
-                    {
-                        Lat = 13.505892,
-                        Lng = 100.8162
-                    },
+                    Center = new LatLngLiteral(13.505892, 100.8162), 
                     MapTypeId = MapTypeId.Roadmap,
                     ApiLoadOptions = await KeyService.GetApiOptions()
                 };
@@ -52,11 +48,7 @@
             var mapOptions2 = new MapOptions()
                 {
                     Zoom = 18,
-                    Center = new LatLngLiteral()
-                    {
-                        Lat = 45.518,
-                        Lng = -122.672
-                    },
+                    Center = new LatLngLiteral(  45.518,  -122.672),
                     MapTypeId = MapTypeId.Satellite,
                     Heading = 90,
                     Tilt = 45,
@@ -83,7 +75,7 @@
 
     private async Task SetMapHeading()
     {
-        double val = await _map2.GetHeading() + 91.261;
+        var val = await _map2.GetHeading() + 91.261;
         await _map2.SetHeading(val);
         var heading = await _map2.GetHeading();
 

--- a/ServerSideDemo/Pages/MapsLegendPage.razor
+++ b/ServerSideDemo/Pages/MapsLegendPage.razor
@@ -47,11 +47,7 @@
         var mapOptions = new MapOptions()
             {
                 Zoom = 13,
-                Center = new LatLngLiteral()
-                {
-                    Lat = 13.505892,
-                    Lng = 100.8162
-                },
+                Center = new LatLngLiteral(13.505892, 100.8162), 
                 MapTypeId = MapTypeId.Roadmap
             };
 

--- a/ServerSideDemo/Pages/TestAllPage.razor.cs
+++ b/ServerSideDemo/Pages/TestAllPage.razor.cs
@@ -23,11 +23,7 @@ public partial class TestAllPage
         _mapOptions = new MapOptions()
         {
             Zoom = 13,
-            Center = new LatLngLiteral()
-            {
-                Lat = 13.505892,
-                Lng = 100.8162
-            },
+            Center = new LatLngLiteral(13.505892, 100.8162), 
             MapTypeId = MapTypeId.Roadmap,
             MapId = "3a3b33f0edd6ed2a"
         };
@@ -204,7 +200,7 @@ public partial class TestAllPage
         }
         await _markerClustering.AddMarkers(markers);
 
-        var boundsLiteral = new LatLngBoundsLiteral(new LatLngLiteral() { Lat = coordinates.First().Lat, Lng = coordinates.First().Lng });
+        var boundsLiteral = new LatLngBoundsLiteral(coordinates.First());
         foreach (var literal in coordinates)
         {
             LatLngBoundsLiteral.CreateOrExtend(ref boundsLiteral, literal);
@@ -244,29 +240,29 @@ public partial class TestAllPage
     {
         return new List<LatLngLiteral>()
         {
-            new() { Lng = 147.154312, Lat = -31.56391},
-            new() { Lng = 150.363181, Lat = -33.718234},
-            new() { Lng = 150.371124, Lat = -33.727111},
-            new() { Lng = 151.209834, Lat = -33.848588},
-            new() { Lng = 151.216968, Lat = -33.851702},
-            new() { Lng = 150.863657, Lat = -34.671264},
-            new() { Lng = 148.662905, Lat = -35.304724},
-            new() { Lng = 175.699196, Lat = -36.817685},
-            new() { Lng = 175.790222, Lat = -36.828611},
-            new() { Lng = 145.116667, Lat = -37.75},
-            new() { Lng = 145.128708, Lat = -37.759859},
-            new() { Lng = 145.133858, Lat = -37.765015},
-            new() { Lng = 145.143299, Lat = -37.770104},
-            new() { Lng = 145.145187, Lat = -37.7737},
-            new() { Lng = 145.137978, Lat = -37.774785},
-            new() { Lng = 144.968119, Lat = -37.819616},
-            new() { Lng = 144.695692, Lat = -38.330766},
-            new() { Lng = 175.053218, Lat = -39.927193},
-            new() { Lng = 174.865694, Lat = -41.330162},
-            new() { Lng = 147.439506, Lat = -42.734358},
-            new() { Lng = 147.501315, Lat = -42.734358},
-            new() { Lng = 147.438, Lat = -42.735258},
-            new() { Lng = 170.463352, Lat = -43.999792},
+            new(147.154312, -31.56391),
+            new(150.363181, -33.718234),
+            new(150.371124, -33.727111),
+            new(151.209834, -33.848588),
+            new(151.216968, -33.851702),
+            new(150.863657, -34.671264),
+            new(148.662905, -35.304724),
+            new(175.699196, -36.817685),
+            new(175.790222, -36.828611),
+            new(145.116667, -37.75),
+            new(145.128708, -37.759859),
+            new(145.133858, -37.765015),
+            new(145.143299, -37.770104),
+            new(145.145187, -37.7737),
+            new(145.137978, -37.774785),
+            new(144.968119, -37.819616),
+            new(144.695692, -38.330766),
+            new(175.053218, -39.927193),
+            new(174.865694, -41.330162),
+            new(147.439506, -42.734358),
+            new(147.501315, -42.734358),
+            new(147.438, -42.735258),
+            new(170.463352, -43.999792),
         };
     }
 
@@ -288,10 +284,9 @@ public partial class TestAllPage
 
         var rnd = new Random();
 
-        return new LatLngLiteral
-        {
-            Lat = bounds.South + rnd.NextDouble() * (bounds.North - bounds.South),
-            Lng = bounds.West + rnd.NextDouble() * (bounds.East - bounds.West)
-        };
+        return new LatLngLiteral(
+            bounds.South + rnd.NextDouble() * (bounds.North - bounds.South),
+        bounds.West + rnd.NextDouble() * (bounds.East - bounds.West)
+        );
     }
 }


### PR DESCRIPTION
**Note**: The changes _may_ seem large, but 99% of the changes simply mean the way LatLngLiteral's are instantiated.

**LatLngLiteral's are now readonly structs**

What does this change?

1. Before, the memory for it was allocated on the heap, not the stack, therefore requiring garbage collection. Now, garbage collection doesn't bother with it. (It also fits better in CPU caches)
2. Class instances have a object header (8-16 bytes, platform dependent), structs do not.
3. The data is now immutable, meaning you'll have to create a new instance rather than alter the data.
4. The data can now be neatly arranged in memory, which is nice if you have polygons or polylines with thousands of vertexes.

Before: a LatLngLiteral instance was ~32-40 bytes (including metadata)
Now: a LatLngLiteral instance has exactly 16 bytes (8 bytes for the 2 doubles)

**Demo changes**
Because a _readonly struct_ can only be created immediately as it is immutable, rather than have assignable properties, the demo's now use the constructor method to instantiate items.

**Warning**

1. Values are now passed by their value, not reference. This may break functionality if a codebase using this library uses a LatLngLiteral between multiple objects and wants updated values to be reflected between those objects. However, I do not see a proper business reason why you'd want that. LatLngLiteral's should be part of a business logic (e.g. referencing a car on the road, or a geofence), not business logic themselves.
2. I have of course tested to see if it didn't break anything using the Server/Client demo's and my employer's codebase and didn't spot anything out of the ordinary, but you'd probably want to test this yourself.

**Not yet implemented**

1. Because the struct is now passed by value, I've decided not to alter methods that take a LatLng value for the sake of not making too many changes to the codebase. However, it may be wise to revisit this later to place ref/in for parameters, for the sake of lowering the amount of copies of state that are passed.
2. ValueTypes such as this (also see how System.Double, System.Int32 etc are implemented) usually use a plethora of interfaces to make working with them easier. Some of those, like IParsable or IFormattable, should be considered in the future. For now I've only done IEquatable because comparing two locations is a very useful tool. 
