### PR TITLE
Combine components into a more controllable interface to simplify new components

### DIFF
--- a/GoogleMapsComponents/AdvancedGoogleMap.razor
+++ b/GoogleMapsComponents/AdvancedGoogleMap.razor
@@ -20,14 +20,9 @@
     
     internal Guid? MapId => MapRef?.InteropObject.Guid;
     
-    public int MarkerCount => _mapComponents.Count;
-    public IEnumerable<MarkerComponent> Markers => _mapComponents.Select(x => x.Value);
-    private readonly Dictionary<Guid, MarkerComponent> _mapComponents = [];
-
-
-    public int PolygonCount => _mapComponents.Count;
-    public IEnumerable<PolygonComponent> Polygons => _mapPolygonComponents.Select(x => x.Value);
-    private readonly Dictionary<Guid, PolygonComponent> _mapPolygonComponents = [];
+    public int ComponentCount => _mapComponents.Count;
+    public IEnumerable<IMapComponent> Components => _mapComponents.Select(x => x.Value);
+    private readonly Dictionary<Guid, IMapComponent> _mapComponents = [];
 
     internal DotNetObjectReference<AdvancedGoogleMap>? CallbackRef;
     
@@ -70,7 +65,7 @@
     [JSInvokable]
     public async Task OnMarkerClicked(Guid markerId)
     {
-        if (_mapComponents.TryGetValue(markerId, out var markerComponent))
+        if (_mapComponents.TryGetValue(markerId, out var component) && component is MarkerComponent markerComponent)
         {
             await markerComponent.MarkerClicked();
         }
@@ -79,7 +74,7 @@
     [JSInvokable]
     public async Task OnMarkerDrag(Guid markerId, LatLngLiteral position)
     {
-        if (_mapComponents.TryGetValue(markerId, out var markerComponent))
+        if (_mapComponents.TryGetValue(markerId, out var component) && component is MarkerComponent markerComponent)
         {
             await markerComponent.MarkerDragged(position);
         }
@@ -88,7 +83,7 @@
     [JSInvokable]
     public async Task OnPolygonClicked(Guid polygonId)
     {
-        if (_mapPolygonComponents.TryGetValue(polygonId, out var polygonComponent))
+        if (_mapComponents.TryGetValue(polygonId, out var component) && component is PolygonComponent polygonComponent)
         {
             await polygonComponent.Click();
         }
@@ -97,48 +92,31 @@
     [JSInvokable]
     public async Task OnPolygonPathChange(Guid polygonId, List<List<LatLngLiteral>> paths)
     {
-        if (_mapPolygonComponents.TryGetValue(polygonId, out var polygonComponent))
+        if (_mapComponents.TryGetValue(polygonId, out var component) && component is PolygonComponent polygonComponent)
         {
             await polygonComponent.PathChanged(paths);
         }
     }
     
-    internal void AddMarker(MarkerComponent marker)
+    internal void RegisterComponent(IMapComponent component)
     {
-        _mapComponents.TryAdd(marker.Guid, marker);
+        _mapComponents.TryAdd(component.Guid, component);
+        //TODO: New callback.
         OnMarkersChanged.InvokeAsync();
     }
     
-    internal void RemoveMarker(MarkerComponent marker)
+    internal void UnregisterComponent(IMapComponent component)
     {
-        _mapComponents.Remove(marker.Guid);
+        _mapComponents.Remove(component.Guid);
         OnMarkersChanged.InvokeAsync();
     }
-
-        internal void AddPolygon(PolygonComponent poly)
-    {
-        _mapPolygonComponents.TryAdd(poly.Guid, poly);
-        OnPolygonsChanged.InvokeAsync();
-    }
-    
-    internal void RemovePolygon(PolygonComponent poly)
-    {
-        _mapPolygonComponents.Remove(poly.Guid);
-        OnPolygonsChanged.InvokeAsync();
-    }
-
 
     public async ValueTask DisposeAsync()
     {
         // Mark components as disposed, since they will be removed by disposing the MapRef.
         foreach (var component in _mapComponents)
         {
-            component.Value.IsDisposed = true;
-        }
-
-        foreach (var component in _mapPolygonComponents)
-        {
-            component.Value.IsDisposed = true;
+            component.Value.SetDisposed();
         }
 
         if (MapRef != null)

--- a/GoogleMapsComponents/Maps/IMapComponent.cs
+++ b/GoogleMapsComponents/Maps/IMapComponent.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace GoogleMapsComponents.Maps;
+
+public interface IMapComponent
+{
+    public Guid Guid { get; }
+    public MapComponentType ComponentType { get; }
+    void SetDisposed();
+}
+
+public enum MapComponentType
+{
+    Marker,
+    Polygon,
+    Heatmap
+}

--- a/GoogleMapsComponents/Maps/MarkerComponent.razor.cs
+++ b/GoogleMapsComponents/Maps/MarkerComponent.razor.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace GoogleMapsComponents.Maps;
 
-public partial class MarkerComponent : IAsyncDisposable, IMarker
+public partial class MarkerComponent : IAsyncDisposable, IMapComponent, IMarker
 {
     public MarkerComponent()
     {
@@ -21,6 +21,7 @@ public partial class MarkerComponent : IAsyncDisposable, IMarker
     private Guid _guid;
 
     public Guid Guid => Id ?? _guid;
+    public MapComponentType ComponentType => MapComponentType.Marker;
 
     [Inject]
     private IJSRuntime Js { get; set; } = default!;
@@ -123,7 +124,7 @@ public partial class MarkerComponent : IAsyncDisposable, IMarker
     {
         if (firstRender)
         {
-            MapRef.AddMarker(this);
+            MapRef.RegisterComponent(this);
             _hasRendered = true;
             await UpdateOptions();
         }
@@ -179,12 +180,17 @@ public partial class MarkerComponent : IAsyncDisposable, IMarker
         }
     }
 
+    public void SetDisposed()
+    {
+        IsDisposed = true;
+    }
+    
     public async ValueTask DisposeAsync()
     {
         if (IsDisposed) return;
         IsDisposed = true;
         await Js.InvokeVoidAsync("blazorGoogleMaps.objectManager.disposeAdvancedMarkerComponent", Guid);
-        MapRef.RemoveMarker(this);
+        MapRef.UnregisterComponent(this);
         GC.SuppressFinalize(this);
     }
 


### PR DESCRIPTION
Here's my suggestion for how to make it somewhat easier to work with, if the users want to get a component via the map they can use the .Components field and then filter based on the ComponentType. Registering new components would be a bit simpler and they can implement the interface to get it to work. This way users can implement their own components, apart from the fact that the events won't really work. 

Settings this as a draft for now, until im sure this is a good solution and I will fix some other parts from the previous PR